### PR TITLE
📅 Reverse direction of calendar fetches

### DIFF
--- a/src/stats.php
+++ b/src/stats.php
@@ -8,7 +8,7 @@ function getContributionGraphs($user): array
     $currentYear = (int) date("Y");
     // build a list of individual requests
     $urls = [];
-    for ($i = $startYear; $i <= $currentYear; $i++) {
+    for ($i = $currentYear; $i >= $startYear; $i--) {
         // set end date (leave parameter out for current year)
         $to = $i < $currentYear ? "?to=" . date("${i}-m-d") : "";
         // create curl request
@@ -40,7 +40,7 @@ function getContributionGraphs($user): array
     // collect responses
     $response = [];
     foreach ($urls as $url) {
-        array_push($response, curl_multi_getcontent($url));
+        array_unshift($response, curl_multi_getcontent($url));
     }
     return $response;
 }


### PR DESCRIPTION
This change addresses #12 although is not a complete fix.

For most users this change will have no effect.

In #12, it was brought up that if the dates have been manually changed to earlier dates such as Dec 31, 1969, more requests will be necessary since all years from the first commit until the present need to be checked for commits. The requests time out after a certain amount and not all contribution graphs end up in the count.

What this PR changes is the order in which the requests are made for fetching contribution graphs so that recent contributions are fetched first. This way if the requests time out, it will not affect the current/longest streak and will only be missing data from very long ago.