### PR TITLE
☑️ Run CI on PR, push to main, and dispatch

### DIFF
--- a/.github/workflows/phpunit-ci-coverage.yml
+++ b/.github/workflows/phpunit-ci-coverage.yml
@@ -1,6 +1,11 @@
 name: PHPUnit CI
 
-on: [push, pull_request]
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   build-test:


### PR DESCRIPTION
Changed CI to only run when pushing to main so that when pushing to pull request it doesn't run twice.