### PR TITLE
🐛 Fix color of dropdown arrows

### DIFF
--- a/src/demo/css/style.css
+++ b/src/demo/css/style.css
@@ -180,6 +180,10 @@ h2 {
   background-position-y: 5px;
 }
 
+[data-theme="dark"] .parameters select {
+  background-image: url("data:image/svg+xml;utf8,<svg fill='white' height='24' viewBox='0 0 24 24' width='24' xmlns='http://www.w3.org/2000/svg'><path d='M7 10l5 5 5-5z'/><path d='M0 0h24v24H0z' fill='none'/></svg>");
+}
+
 .parameters select option[disabled] {
   display: none;
 }


### PR DESCRIPTION
## Description

Fixed the color dropdown arrows on [Demo Site](https://github-readme-streak-stats.herokuapp.com/demo/). The color is white in DarkMode and black in LightMode.

Fixes #75 

### Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (added a non-breaking change which fixes an issue)
- [ ] New feature (added a non-breaking change which adds functionality)
- [ ] Updated documentation (updated the readme, templates, or other repo files)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

<!-- If you have changed a feature of the stats cards, please describe the tests you made to verify your changes. -->

- [x] Tested locally with a valid username
- [x] Tested locally with an invalid username
- [ ] Ran tests with `composer test`
- [ ] Added or updated test cases to test new features

## Checklist:

- [x] I have checked to make sure no other [pull requests](https://github.com/DenverCoder1/github-readme-streak-stats/pulls?q=is%3Apr+sort%3Aupdated-desc+) are open for this issue
- [x] The code is properly formatted and is consistent with the existing code style
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Screenshots

> Source Code

![image](https://user-images.githubusercontent.com/74750414/114898342-a1cab500-9e2f-11eb-8455-01cc43b34bdb.png)


> Light Mode Theme

![image](https://user-images.githubusercontent.com/74750414/114897430-d9852d00-9e2e-11eb-96d7-858625090366.png)

> Dark Mode Theme

![image](https://user-images.githubusercontent.com/74750414/114897919-51ebee00-9e2f-11eb-9545-0d452fa68084.png)


