### PR TITLE
🐛 Reset current streak endpoints when streak broken

### DIFF
--- a/src/index.php
+++ b/src/index.php
@@ -34,7 +34,8 @@ if (!isset($_REQUEST["user"])) {
 
 try {
     // get streak stats for user given in query string
-    $stats = getContributionStats($_REQUEST["user"]);
+    $contributions = getContributionDates($_REQUEST["user"]);
+    $stats = getContributionStats($contributions);
 } catch (InvalidArgumentException $error) {
     die(generateErrorCard($error->getMessage()));
 }

--- a/src/stats.php
+++ b/src/stats.php
@@ -67,7 +67,9 @@ function getContributionDates(string $user): array
             if (isset($dateMatch[1]) && isset($countMatch[1])) {
                 $date = $dateMatch[1];
                 $count = (int) $countMatch[1];
-                if ($date <= $currentDate) {
+                // count contributions up until today
+                // also count next day if user contributed already
+                if ($date <= $currentDate || $count > 0) {
                     // add contributions to the array
                     $contributions[$date] = $count;
                 }

--- a/src/stats.php
+++ b/src/stats.php
@@ -134,9 +134,8 @@ function getYearJoined(string $user): int
 /**
  * Get a stats array with the contribution count, streak, and dates
  */
-function getContributionStats(string $user): array
+function getContributionStats(array $contributions): array
 {
-    $contributions = getContributionDates($user);
     $today = array_key_last($contributions);
     $stats = [
         "totalContributions" => 0,
@@ -182,6 +181,8 @@ function getContributionStats(string $user): array
         elseif ($date != $today) {
             // reset streak
             $stats["currentStreak"]["length"] = 0;
+            $stats["currentStreak"]["start"] = $today;
+            $stats["currentStreak"]["end"] = $today;
         }
     }
     return $stats;


### PR DESCRIPTION
## Description

When current streak is reset, the date range should be removed.

![image](https://user-images.githubusercontent.com/20955511/115166687-22eaac00-a0bd-11eb-99ba-4148b619ecf2.png)

### Type of change

- [x] Bug fix (added a non-breaking change which fixes an issue)

## How Has This Been Tested?

<!-- If you have changed a feature of the stats cards, please describe the tests you made to verify your changes. -->

- [x] Tested locally with a valid username
- [x] Tested locally with an invalid username
- [x] Ran tests with `composer test`
- [x] Added or updated test cases to test new features

## Checklist:

- [x] I have checked to make sure no other [pull requests](https://github.com/DenverCoder1/github-readme-streak-stats/pulls?q=is%3Apr+sort%3Aupdated-desc+) are open for this issue
- [x] The code is properly formatted and is consistent with the existing code style
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
