### PR TITLE
Only check 1 day ahead for future commits

### DIFF
--- a/src/card.php
+++ b/src/card.php
@@ -1,7 +1,10 @@
 <?php declare (strict_types = 1);
 
 /**
- * Convert date from YYYY-MM-DD to more human-readable format
+ * Convert date from Y-M-D to more human-readable format
+ * 
+ * @param string $dateString String in Y-M-D format
+ * @return string formatted date string
  */
 function formatDate(string $dateString): string
 {
@@ -16,6 +19,8 @@ function formatDate(string $dateString): string
 
 /**
  * Check theme and color customization parameters to generate a theme mapping
+ * 
+ * @return array<string, string> the chosen theme or default
  */
 function getRequestedTheme(): array
 {
@@ -60,6 +65,11 @@ function getRequestedTheme(): array
 
 /**
  * Generate SVG output for a stats array
+ * 
+ * @param array<string, mixed> $stats Streak Stats
+ * @param array<string, string>|NULL $theme the selected theme
+ * 
+ * @return string The generated SVG Streak Stats card
  */
 function generateCard(array $stats, array $theme = null): string
 {
@@ -214,6 +224,11 @@ function generateCard(array $stats, array $theme = null): string
 
 /**
  * Generate SVG displaying an error message
+ * 
+ * @param string $message The error message to display
+ * @param array<string, string>|NULL $theme The selected theme
+ * 
+ * @return string The generated SVG error card
  */
 function generateErrorCard(string $message, array $theme = null): string
 {

--- a/src/card.php
+++ b/src/card.php
@@ -27,7 +27,7 @@ function getRequestedTheme(array $params): array
 {
     /**
      * @var array<string, array<string, string>> $THEMES
-     * Get theme colors
+     * List of theme names mapped to labeled colors
      */
     $THEMES = include "themes.php";
 
@@ -37,6 +37,7 @@ function getRequestedTheme(array $params): array
      */
     $CSS_COLORS = include "colors.php";
 
+    // get theme colors
     if (isset($params["theme"]) && array_key_exists($params["theme"], $THEMES)) {
         $theme = $THEMES[$params["theme"]];
     }

--- a/src/card.php
+++ b/src/card.php
@@ -20,9 +20,10 @@ function formatDate(string $dateString): string
 /**
  * Check theme and color customization parameters to generate a theme mapping
  *
+ * @param array<string, string> $params Request parameters
  * @return array<string, string> The chosen theme or default
  */
-function getRequestedTheme(): array
+function getRequestedTheme(array $params): array
 {
     /**
      * @var array<string, array<string, string>> $THEMES
@@ -36,8 +37,8 @@ function getRequestedTheme(): array
      */
     $CSS_COLORS = include "colors.php";
 
-    if (isset($_REQUEST["theme"]) && array_key_exists($_REQUEST["theme"], $THEMES)) {
-        $theme = $THEMES[$_REQUEST["theme"]];
+    if (isset($params["theme"]) && array_key_exists($params["theme"], $THEMES)) {
+        $theme = $THEMES[$params["theme"]];
     }
     // no theme specified, get default
     else {
@@ -48,9 +49,9 @@ function getRequestedTheme(): array
     $properties = array_keys($theme);
     foreach ($properties as $prop) {
         // check if each property was passed as a parameter
-        if (isset($_REQUEST[$prop])) {
+        if (isset($params[$prop])) {
             // ignore case
-            $param = strtolower($_REQUEST[$prop]);
+            $param = strtolower($params[$prop]);
             // check if color is valid hex color (3, 4, 6, or 8 hex digits)
             if (preg_match("/^([a-f0-9]{3}|[a-f0-9]{4}|[a-f0-9]{6}|[a-f0-9]{8})$/", $param)) {
                 // set property
@@ -65,7 +66,7 @@ function getRequestedTheme(): array
     }
 
     // hide borders
-    if (isset($_REQUEST["hide_border"]) && $_REQUEST["hide_border"] == "true") {
+    if (isset($params["hide_border"]) && $params["hide_border"] == "true") {
         $theme["border"] = "#0000"; // transparent
     }
 
@@ -76,14 +77,14 @@ function getRequestedTheme(): array
  * Generate SVG output for a stats array
  *
  * @param array<string, mixed> $stats Streak stats
- * @param array<string, string>|NULL $theme The selected theme or null
+ * @param array<string, string>|NULL $params Request parameters
  *
  * @return string The generated SVG Streak Stats card
  */
-function generateCard(array $stats, array $theme = null): string
+function generateCard(array $stats, array $params = null): string
 {
-    // get requested theme if $theme is null
-    $theme = $theme ?? getRequestedTheme();
+    // get requested theme, use $_REQUEST if no params array specified
+    $theme = getRequestedTheme($params ?? $_REQUEST);
 
     // total contributions
     $totalContributions = $stats["totalContributions"];
@@ -235,14 +236,14 @@ function generateCard(array $stats, array $theme = null): string
  * Generate SVG displaying an error message
  *
  * @param string $message The error message to display
- * @param array<string, string>|NULL $theme The selected theme or null
+ * @param array<string, string>|NULL $params Request parameters
  *
  * @return string The generated SVG error card
  */
-function generateErrorCard(string $message, array $theme = null): string
+function generateErrorCard(string $message, array $params = null): string
 {
-    // get requested theme if $theme is null
-    $theme = $theme ?? getRequestedTheme();
+    // get requested theme, use $_REQUEST if no params array specified
+    $theme = getRequestedTheme($params ?? $_REQUEST);
 
     return "
     <svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' style='isolation:isolate' viewBox='0 0 495 195' width='495px' height='195px'>

--- a/src/card.php
+++ b/src/card.php
@@ -2,9 +2,9 @@
 
 /**
  * Convert date from Y-M-D to more human-readable format
- * 
+ *
  * @param string $dateString String in Y-M-D format
- * @return string formatted date string
+ * @return string formatted Date string
  */
 function formatDate(string $dateString): string
 {
@@ -19,24 +19,33 @@ function formatDate(string $dateString): string
 
 /**
  * Check theme and color customization parameters to generate a theme mapping
- * 
- * @return array<string, string> the chosen theme or default
+ *
+ * @return array<string, string> The chosen theme or default
  */
 function getRequestedTheme(): array
 {
-    // get theme colors
-    $themes = include "themes.php";
-    if (isset($_REQUEST["theme"]) && array_key_exists($_REQUEST["theme"], $themes)) {
-        $theme = $themes[$_REQUEST["theme"]];
+    /**
+     * @var array<string, array<string, string>> $THEMES
+     * Get theme colors
+     */
+    $THEMES = include "themes.php";
+
+    /**
+     * @var array<string> $CSS_COLORS
+     * List of valid CSS colors
+     */
+    $CSS_COLORS = include "colors.php";
+
+    if (isset($_REQUEST["theme"]) && array_key_exists($_REQUEST["theme"], $THEMES)) {
+        $theme = $THEMES[$_REQUEST["theme"]];
     }
     // no theme specified, get default
     else {
-        $theme = $themes["default"];
+        $theme = $THEMES["default"];
     }
 
     // personal theme customizations
     $properties = array_keys($theme);
-    $cssColors = include "colors.php";
     foreach ($properties as $prop) {
         // check if each property was passed as a parameter
         if (isset($_REQUEST[$prop])) {
@@ -48,7 +57,7 @@ function getRequestedTheme(): array
                 $theme[$prop] = "#" . $param;
             }
             // check if color is valid css color
-            else if (in_array($param, $cssColors)) {
+            else if (in_array($param, $CSS_COLORS)) {
                 // set property
                 $theme[$prop] = $param;
             }
@@ -65,10 +74,10 @@ function getRequestedTheme(): array
 
 /**
  * Generate SVG output for a stats array
- * 
- * @param array<string, mixed> $stats Streak Stats
- * @param array<string, string>|NULL $theme the selected theme
- * 
+ *
+ * @param array<string, mixed> $stats Streak stats
+ * @param array<string, string>|NULL $theme The selected theme or null
+ *
  * @return string The generated SVG Streak Stats card
  */
 function generateCard(array $stats, array $theme = null): string
@@ -224,10 +233,10 @@ function generateCard(array $stats, array $theme = null): string
 
 /**
  * Generate SVG displaying an error message
- * 
+ *
  * @param string $message The error message to display
- * @param array<string, string>|NULL $theme The selected theme
- * 
+ * @param array<string, string>|NULL $theme The selected theme or null
+ *
  * @return string The generated SVG error card
  */
 function generateErrorCard(string $message, array $theme = null): string

--- a/src/index.php
+++ b/src/index.php
@@ -34,7 +34,7 @@ if (!isset($_REQUEST["user"])) {
 
 try {
     // get streak stats for user given in query string
-    $contributionGraphs = getContributionGraphs($user);
+    $contributionGraphs = getContributionGraphs($_REQUEST["user"]);
     $contributions = getContributionDates($contributionGraphs);
     $stats = getContributionStats($contributions);
 } catch (InvalidArgumentException $error) {

--- a/src/index.php
+++ b/src/index.php
@@ -34,7 +34,8 @@ if (!isset($_REQUEST["user"])) {
 
 try {
     // get streak stats for user given in query string
-    $contributions = getContributionDates($_REQUEST["user"]);
+    $contributionGraphs = getContributionGraphs($user);
+    $contributions = getContributionDates($contributionGraphs);
     $stats = getContributionStats($contributions);
 } catch (InvalidArgumentException $error) {
     die(generateErrorCard($error->getMessage()));

--- a/src/stats.php
+++ b/src/stats.php
@@ -54,19 +54,17 @@ function getContributionGraphs(string $user): array
  * Get an array of all dates with the number of contributions
  *
  * @param array<string> $contributionGraphs List of HTML pages with contributions
- * @return array<string, int>
+ * @return array<string, int> Y-M-D dates mapped to the number of contributions
  */
-function getContributionDates(string $user): array
+function getContributionDates(array $contributionGraphs): array
 {
-    // fetch html for all contribution graphs
-    $contributionsHTML = getContributionGraphs($user);
     // get contributions from HTML
     $contributions = array();
     $today = date("Y-m-d");
     $tomorrow = date("Y-m-d", strtotime("tomorrow"));
-    foreach ($contributionsHTML as $html) {
+    foreach ($contributionGraphs as $graph) {
         // split into lines
-        $lines = explode("\n", $html);
+        $lines = explode("\n", $graph);
         // add the dates and contribution counts to the array
         foreach ($lines as $line) {
             preg_match("/ data-date=\"([0-9\-]{10})\"/", $line, $dateMatch);
@@ -87,12 +85,12 @@ function getContributionDates(string $user): array
 }
 
 /**
- * Get the contents of a single URL
+ * Get the contents of a single URL passing headers for GitHub API
  * 
  * @param string $url URL to fetch
  * @return string contents of the page
  */
-function curl_get_contents(string $url): string
+function getGitHubApiResponse(string $url): string
 {
     $ch = curl_init();
     $token = getenv("TOKEN");
@@ -123,7 +121,7 @@ function curl_get_contents(string $url): string
 function getYearJoined(string $user): int
 {
     // load the user's profile info
-    $response = curl_get_contents("https://api.github.com/users/${user}");
+    $response = getGitHubApiResponse("https://api.github.com/users/${user}");
     $json = json_decode($response);
     // find the year the user was created
     if ($json && isset($json->type) && $json->type == "User" && isset($json->created_at)) {

--- a/src/stats.php
+++ b/src/stats.php
@@ -88,7 +88,7 @@ function getContributionDates(array $contributionGraphs): array
  * Get the contents of a single URL passing headers for GitHub API
  * 
  * @param string $url URL to fetch
- * @return string contents of the page
+ * @return string Response from page as a string
  */
 function getGitHubApiResponse(string $url): string
 {
@@ -148,7 +148,7 @@ function getYearJoined(string $user): int
  * Get a stats array with the contribution count, streak, and dates
  * 
  * @param array<string, int> $contributions Y-M-D contribution dates with contribution counts
- * @return array<string, mixed> streak stats
+ * @return array<string, mixed> Streak stats
  */
 function getContributionStats(array $contributions): array
 {

--- a/src/stats.php
+++ b/src/stats.php
@@ -2,6 +2,9 @@
 
 /**
  * Get all HTTP request responses for user's contributions
+ *
+ * @param string $user GitHub username to get graphs for
+ * @return array<string> List of HTML contribution graphs
  */
 function getContributionGraphs(string $user): array
 {
@@ -49,6 +52,9 @@ function getContributionGraphs(string $user): array
 
 /**
  * Get an array of all dates with the number of contributions
+ *
+ * @param array<string> $contributionGraphs List of HTML pages with contributions
+ * @return array<string, int>
  */
 function getContributionDates(string $user): array
 {
@@ -82,6 +88,9 @@ function getContributionDates(string $user): array
 
 /**
  * Get the contents of a single URL
+ * 
+ * @param string $url URL to fetch
+ * @return string contents of the page
  */
 function curl_get_contents(string $url): string
 {
@@ -107,6 +116,9 @@ function curl_get_contents(string $url): string
 
 /**
  * Get the first year a user contributed
+ * 
+ * @param string $user GitHub username to look up
+ * @return int first contribution year
  */
 function getYearJoined(string $user): int
 {
@@ -136,6 +148,9 @@ function getYearJoined(string $user): int
 
 /**
  * Get a stats array with the contribution count, streak, and dates
+ * 
+ * @param array<string, int> $contributions Y-M-D contribution dates with contribution counts
+ * @return array<string, mixed> streak stats
  */
 function getContributionStats(array $contributions): array
 {

--- a/src/stats.php
+++ b/src/stats.php
@@ -56,7 +56,8 @@ function getContributionDates(string $user): array
     $contributionsHTML = getContributionGraphs($user);
     // get contributions from HTML
     $contributions = array();
-    $currentDate = date("Y-m-d");
+    $today = date("Y-m-d");
+    $tomorrow = date("Y-m-d", strtotime("tomorrow"));
     foreach ($contributionsHTML as $html) {
         // split into lines
         $lines = explode("\n", $html);
@@ -69,7 +70,7 @@ function getContributionDates(string $user): array
                 $count = (int) $countMatch[1];
                 // count contributions up until today
                 // also count next day if user contributed already
-                if ($date <= $currentDate || $count > 0) {
+                if ($date <= $today || ($date == $tomorrow && $count > 0)) {
                     // add contributions to the array
                     $contributions[$date] = $count;
                 }

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -27,8 +27,8 @@ final class OptionsTest extends TestCase
         // check that getRequestedTheme returns correct colors for each theme
         $themes = include "src/themes.php";
         foreach ($themes as $theme => $colors) {
-            $_REQUEST = ["theme" => $theme];
-            $actualColors = getRequestedTheme();
+            $params = ["theme" => $theme];
+            $actualColors = getRequestedTheme($params);
             $this->assertEquals($colors, $actualColors);
         }
     }
@@ -40,9 +40,9 @@ final class OptionsTest extends TestCase
     {
         // check that getRequestedTheme returns default for invalid theme
         // request parameters
-        $_REQUEST = ["theme" => "not a theme name"];
+        $params = ["theme" => "not a theme name"];
         // test that invalid theme name gives default values
-        $this->assertEquals($this->defaultTheme, getRequestedTheme());
+        $this->assertEquals($this->defaultTheme, getRequestedTheme($params));
     }
 
     /**
@@ -84,19 +84,19 @@ final class OptionsTest extends TestCase
     public function testColorOverrideParameters(): void
     {
         // clear request parameters
-        $_REQUEST = [];
+        $params = [];
         // set default expected value
         $expected = $this->defaultTheme;
         foreach (array_keys($this->defaultTheme) as $param) {
             // set request parameter
-            $_REQUEST[$param] = "f00";
+            $params[$param] = "f00";
             // update parameter in expected result
             $expected = array_merge(
                 $expected,
                 [$param => "#f00"],
             );
             // test color change
-            $this->assertEquals($expected, getRequestedTheme());
+            $this->assertEquals($expected, getRequestedTheme($params));
         }
     }
 
@@ -118,14 +118,14 @@ final class OptionsTest extends TestCase
         $expected = $this->defaultTheme;
         foreach ($validInputTypes as $input => $output) {
             // set request parameter
-            $_REQUEST = ["background" => $input];
+            $params = ["background" => $input];
             // update parameter in expected result
             $expected = array_merge(
                 $expected,
                 ["background" => $output],
             );
             // test color change
-            $this->assertEquals($expected, getRequestedTheme());
+            $this->assertEquals($expected, getRequestedTheme($params));
         }
     }
 
@@ -142,9 +142,9 @@ final class OptionsTest extends TestCase
         ];
         foreach ($invalidInputTypes as $input) {
             // set request parameter
-            $_REQUEST = ["background" => $input];
+            $params = ["background" => $input];
             // test that theme is still default
-            $this->assertEquals($this->defaultTheme, getRequestedTheme());
+            $this->assertEquals($this->defaultTheme, getRequestedTheme($params));
         }
     }
 
@@ -154,12 +154,12 @@ final class OptionsTest extends TestCase
     public function testHideBorder(): void
     {
         // check that getRequestedTheme returns transparent border when hide_border is true
-        $_REQUEST = ["hide_border" => "true"];
-        $theme = getRequestedTheme();
+        $params = ["hide_border" => "true"];
+        $theme = getRequestedTheme($params);
         $this->assertEquals("#0000", $theme["border"]);
         // check that getRequestedTheme returns solid border when hide_border is not true
-        $_REQUEST = ["hide_border" => "false"];
-        $theme = getRequestedTheme();
+        $params = ["hide_border" => "false"];
+        $theme = getRequestedTheme($params);
         $this->assertEquals($this->defaultTheme["border"], $theme["border"]);
     }
 

--- a/tests/RenderTest.php
+++ b/tests/RenderTest.php
@@ -6,17 +6,17 @@ require_once "src/card.php";
 
 final class RenderTest extends TestCase
 {
-    private $testTheme = array(
-        "background" => "#000000",
-        "border" => "#111111",
-        "stroke" => "#222222",
-        "ring" => "#333333",
-        "fire" => "#444444",
-        "currStreakNum" => "#555555",
-        "sideNums" => "#666666",
-        "currStreakLabel" => "#777777",
-        "sideLabels" => "#888888",
-        "dates" => "#999999",
+    private $testParams = array(
+        "background" => "000000",
+        "border" => "111111",
+        "stroke" => "222222",
+        "ring" => "333333",
+        "fire" => "444444",
+        "currStreakNum" => "555555",
+        "sideNums" => "666666",
+        "currStreakLabel" => "777777",
+        "sideLabels" => "888888",
+        "dates" => "999999",
     );
 
     private $testStats = array(
@@ -40,7 +40,7 @@ final class RenderTest extends TestCase
     public function testCardRender(): void
     {
         // check that getRequestedTheme returns correct colors for each theme
-        $render = generateCard($this->testStats, $this->testTheme);
+        $render = generateCard($this->testStats, $this->testParams);
         $expected = file_get_contents("tests/svg/test_card.svg");
         $this->assertEquals($expected, $render);
     }
@@ -51,7 +51,7 @@ final class RenderTest extends TestCase
     public function testErrorCardRender(): void
     {
         // check that getRequestedTheme returns correct colors for each theme
-        $render = generateErrorCard("An unknown error occurred", $this->testTheme);
+        $render = generateErrorCard("An unknown error occurred", $this->testParams);
         $expected = file_get_contents("tests/svg/test_error_card.svg");
         $this->assertEquals($expected, $render);
     }

--- a/tests/StatsTest.php
+++ b/tests/StatsTest.php
@@ -23,7 +23,8 @@ final class StatsTest extends TestCase
      */
     public function testValidUsername(): void
     {
-        $contributions = getContributionDates("DenverCoder1");
+        $contributionGraphs = getContributionGraphs("DenverCoder1");
+        $contributions = getContributionDates($contributionGraphs);
         $stats = getContributionStats($contributions);
         // test total contributions
         $this->assertIsInt($stats["totalContributions"]);
@@ -61,7 +62,7 @@ final class StatsTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage("User could not be found.");
-        getContributionDates("help");
+        getContributionGraphs("help");
     }
 
     /**
@@ -72,6 +73,7 @@ final class StatsTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage("The username given is not a user.");
         getContributionDates("DenverCoderOne");
+        getContributionGraphs("DenverCoderOne");
     }
 
     /**

--- a/tests/StatsTest.php
+++ b/tests/StatsTest.php
@@ -72,7 +72,6 @@ final class StatsTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage("The username given is not a user.");
-        getContributionDates("DenverCoderOne");
         getContributionGraphs("DenverCoderOne");
     }
 

--- a/tests/StatsTest.php
+++ b/tests/StatsTest.php
@@ -188,4 +188,39 @@ final class StatsTest extends TestCase
         );
         $this->assertEquals($expected, $stats);
     }
+
+    /**
+     * Test future commits
+     * Tomorrow should count because of timezone differences, but further ahead should not
+     */
+    public function testFutureCommits(): void
+    {
+        $yesterday = date('Y-m-d', strtotime('yesterday'));
+        $today = date('Y-m-d', strtotime('today'));
+        $tomorrow = date('Y-m-d', strtotime('tomorrow'));
+        $inTwoDays = date('Y-m-d', strtotime("$today +2 days"));
+        $contributionGraphs = [
+            "<rect width=\"10\" height=\"10\" x=\"-2\" y=\"13\" class=\"ContributionCalendar-day\" rx=\"2\" ry=\"2\" data-count=\"1\" data-date=\"$yesterday\" data-level=\"1\"></rect>
+            <rect width=\"10\" height=\"10\" x=\"-2\" y=\"26\" class=\"ContributionCalendar-day\" rx=\"2\" ry=\"2\" data-count=\"1\" data-date=\"$today\" data-level=\"2\"></rect>
+            <rect width=\"10\" height=\"10\" x=\"-2\" y=\"39\" class=\"ContributionCalendar-day\" rx=\"2\" ry=\"2\" data-count=\"1\" data-date=\"$tomorrow\" data-level=\"0\"></rect>
+            <rect width=\"10\" height=\"10\" x=\"-2\" y=\"52\" class=\"ContributionCalendar-day\" rx=\"2\" ry=\"2\" data-count=\"1\" data-date=\"$inTwoDays\" data-level=\"0\"></rect>"
+        ];
+        $contributions = getContributionDates($contributionGraphs);
+        $stats = getContributionStats($contributions);
+        $expected = array(
+            "totalContributions" => 3,
+            "firstContribution" => date('Y-m-d', strtotime('yesterday')),
+            "longestStreak" => [
+                "start" => date('Y-m-d', strtotime('yesterday')),
+                "end" => date('Y-m-d', strtotime('tomorrow')),
+                "length" => 3,
+            ],
+            "currentStreak" => [
+                "start" => date('Y-m-d', strtotime('yesterday')),
+                "end" => date('Y-m-d', strtotime('tomorrow')),
+                "length" => 3,
+            ],
+        );
+        $this->assertEquals($expected, $stats);
+    }
 }


### PR DESCRIPTION
## Description

Commits dates that are far in the future will get ignored so that current streak numbers make more sense.

Fixes #83

### Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (added a non-breaking change which fixes an issue)

## How Has This Been Tested?

<!-- If you have changed a feature of the stats cards, please describe the tests you made to verify your changes. -->

- [x] Tested locally with a valid username
- [x] Tested locally with an invalid username
- [x] Ran tests with `composer test`
- [x] Added or updated test cases to test new features

## Checklist:

- [x] I have checked to make sure no other [pull requests](https://github.com/DenverCoder1/github-readme-streak-stats/pulls?q=is%3Apr+sort%3Aupdated-desc+) are open for this issue
- [x] The code is properly formatted and is consistent with the existing code style
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings