### PR TITLE
set darkmode on userpreference

### DIFF
--- a/src/demo/js/toggle-dark.js
+++ b/src/demo/js/toggle-dark.js
@@ -1,10 +1,8 @@
-const icon = document.querySelector(".darkmode i");
-if (getCookie("darkmode") === null) {
-  if (window.matchMedia("(prefers-color-scheme: dark)").matches == true) {
-    darkmode();
-  } else {
-    lightmode();
-  }
+if (
+  getCookie("darkmode") === null &&
+  window.matchMedia("(prefers-color-scheme: dark)").matches == true
+) {
+  darkmode();
 }
 
 function toggleTheme() {

--- a/src/demo/js/toggle-dark.js
+++ b/src/demo/js/toggle-dark.js
@@ -1,17 +1,30 @@
+const icon = document.querySelector(".darkmode i");
+if (window.matchMedia("(prefers-color-scheme: dark)").matches == true) {
+  darkmode();
+} else {
+  lightmode();
+}
+
 function toggleTheme() {
-  const icon = document.querySelector(".darkmode i");
-  /* dark mode on */
   if (document.body.getAttribute("data-theme") !== "dark") {
-    icon.className = "gg-sun";
-    setCookie("darkmode", "on", 9999);
-    document.body.setAttribute("data-theme", "dark");
+    /* dark mode on */
+    darkmode();
+  } else {
+    /* dark mode off */
+    lightmode();
   }
-  /* dark mode off */
-  else {
-    icon.className = "gg-moon";
-    setCookie("darkmode", "off", 9999);
-    document.body.removeAttribute("data-theme");
-  }
+}
+
+function darkmode() {
+  icon.className = "gg-sun";
+  setCookie("darkmode", "on", 9999);
+  document.body.setAttribute("data-theme", "dark");
+}
+
+function lightmode() {
+  icon.className = "gg-moon";
+  setCookie("darkmode", "off", 9999);
+  document.body.removeAttribute("data-theme");
 }
 
 function setCookie(cname, cvalue, exdays) {

--- a/src/demo/js/toggle-dark.js
+++ b/src/demo/js/toggle-dark.js
@@ -18,17 +18,16 @@ function toggleTheme() {
 }
 
 function darkmode() {
-  icon.className = "gg-sun";
+  document.querySelector(".darkmode i").className = "gg-sun";
   setCookie("darkmode", "on", 9999);
   document.body.setAttribute("data-theme", "dark");
 }
 
 function lightmode() {
-  icon.className = "gg-moon";
+  document.querySelector(".darkmode i").className = "gg-moon";
   setCookie("darkmode", "off", 9999);
   document.body.removeAttribute("data-theme");
 }
-
 function setCookie(cname, cvalue, exdays) {
   var d = new Date();
   d.setTime(d.getTime() + exdays * 24 * 60 * 60 * 1000);

--- a/src/demo/js/toggle-dark.js
+++ b/src/demo/js/toggle-dark.js
@@ -1,8 +1,10 @@
 const icon = document.querySelector(".darkmode i");
-if (window.matchMedia("(prefers-color-scheme: dark)").matches == true) {
-  darkmode();
-} else {
-  lightmode();
+if (getCookie("darkmode") === null) {
+  if (window.matchMedia("(prefers-color-scheme: dark)").matches == true) {
+    darkmode();
+  } else {
+    lightmode();
+  }
 }
 
 function toggleTheme() {
@@ -32,4 +34,21 @@ function setCookie(cname, cvalue, exdays) {
   d.setTime(d.getTime() + exdays * 24 * 60 * 60 * 1000);
   var expires = "expires=" + d.toUTCString();
   document.cookie = cname + "=" + cvalue + ";" + expires + ";path=/";
+}
+
+function getCookie(name) {
+  var dc = document.cookie;
+  var prefix = name + "=";
+  var begin = dc.indexOf("; " + prefix);
+  if (begin == -1) {
+    begin = dc.indexOf(prefix);
+    if (begin != 0) return null;
+  } else {
+    begin += 2;
+    var end = document.cookie.indexOf(";", begin);
+    if (end == -1) {
+      end = dc.length;
+    }
+  }
+  return decodeURI(dc.substring(begin + prefix.length, end));
 }


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. -->

this PR implements the feature that the theme is set on the user preference in the browser using 

```js
window.matchMedia("(prefers-color-scheme: dark)")
```

![image](https://user-images.githubusercontent.com/30869493/117395540-697f3980-aef8-11eb-8a63-224e3975c46e.png)

### Type of change

- [x] New feature (added a non-breaking change which adds functionality)

## How Has This Been Tested?

<!-- If you have changed a feature of the stats cards, please describe the tests you made to verify your changes. -->

- [x] Tested locally with a valid username
- [x] Tested locally with an invalid username
- [x] Ran tests with `composer test`
- [x] Added or updated test cases to test new features

## Checklist:

- [x] I have checked to make sure no other [pull requests](https://github.com/DenverCoder1/github-readme-streak-stats/pulls?q=is%3Apr+sort%3Aupdated-desc+) are open for this issue
- [x] The code is properly formatted and is consistent with the existing code style
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings