### PR TITLE
🔼 Add line about tests for documentation changes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,7 +15,10 @@ Fixes # <!-- add issue number -->
 
 ## How Has This Been Tested?
 
-<!-- If you have changed a feature of the stats cards, please describe the tests you made to verify your changes. -->
+<!-- 
+If you have changed a feature of the stats cards, please describe the tests you made to verify your changes. 
+Changes strictly related to documentation can skip this section.
+-->
 
 - [ ] Tested locally with a valid username
 - [ ] Tested locally with an invalid username


### PR DESCRIPTION
Updated PR template to mention that running tests is not necessary for documentation updates