### PR TITLE
Add badge with user count from search results

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 </p>
 
 <p align="center">
+  <a href="https://github.com/search?q=extension%3Amd+%22github+readme+streak+stats+herokuapp%22&type=Code" alt="Users" title="Repo users">
+    <img src="https://freshidea.com/jonah/app/streak-stats-users/index.php"/></a>
   <a href="https://discord.gg/fPrdqh3Zfu" alt="Discord" title="Dev Pro Tips Discussion & Support Server">
     <img src="https://img.shields.io/discord/819650821314052106?color=7289DA&logo=discord&logoColor=white&style=for-the-badge"/></a>
 </p>


### PR DESCRIPTION
## Description

Badge uses GitHub API search results to count users of the badge in a markdown file

![image](https://user-images.githubusercontent.com/20955511/124926190-e5375880-e005-11eb-9e02-5137ce4df5d7.png)

### Type of change

<!-- Please delete options that are not relevant. -->

- [x] Updated documentation (updated the readme, templates, or other repo files)