### PR TITLE
Removed table of contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,18 +16,6 @@
     <img src="https://img.shields.io/discord/819650821314052106?color=7289DA&logo=discord&logoColor=white&style=for-the-badge"/></a>
 </p>
 
-## 📃 Table of Contents
-
-- [📃 Table of Contents](#-table-of-contents)
-- [⚡ Quick setup](#-quick-setup)
-- [⚙ Demo Site](#-demo-site)
-- [🖌 Themes](#-themes)
-- [🔧 Options](#-options)
-- [ℹ️ How these stats are calculated](#ℹ️-how-these-stats-are-calculated)
-- [📤 Deploying it on your own](#-deploying-it-on-your-own)
-- [🤗 Contributing](#-contributing)
-- [🙋‍♂️ Support](#️-support)
-
 ## ⚡ Quick setup
 
 1. Copy-paste the markdown below into your GitHub profile README


### PR DESCRIPTION
No longer needed since it's built in to github

![image](https://user-images.githubusercontent.com/20955511/128613147-921b1866-3d28-4217-bf16-e13bb88b6e73.png)

Fixes #121 