### PR TITLE
Remove directory from config.php example

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,6 @@ To get the GitHub API to run locally you will need to provide a token.
 3. **Create a file** `config.php` in the `src` directory and replace `ghp_example123` with **your token** and `DenverCoder1` with **your username**:
 
 ```php
-# /src/config.php
 <?php
 putenv("TOKEN=ghp_example123");
 putenv("USERNAME=DenverCoder1");


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. -->

Removes the directory comment from the `config.php` code block example due to the `#` character causing php to fail to display the web page.

### Type of change

<!-- Please delete options that are not relevant. -->

- [x] Updated documentation (updated the readme, templates, or other repo files)

## Checklist:

- [x] I have checked to make sure no other [pull requests](https://github.com/DenverCoder1/github-readme-streak-stats/pulls?q=is%3Apr+sort%3Aupdated-desc+) are open for this issue