### PR TITLE
Remove hex value if color is fully opaque

### DIFF
--- a/src/demo/js/script.js
+++ b/src/demo/js/script.js
@@ -76,7 +76,7 @@ let preview = {
       input.id = property;
       input.name = property;
       input.setAttribute("data-property", property);
-      input.setAttribute("data-jscolor", "{ format: 'hexa' }");
+      input.setAttribute("data-jscolor", "{ format: 'hexa', onInput: 'pickerChange(this, \"" + property + "\")' }");
       input.value = value;
       // removal button
       const minus = document.createElement("button");
@@ -95,6 +95,9 @@ let preview = {
 
       //initialise jscolor on element
       jscolor.install(parent);
+
+      // check initial color value
+      checkColor(value, property);
 
       // update and exit
       this.update();
@@ -171,3 +174,15 @@ window.addEventListener(
   },
   false
 );
+
+function checkColor(color, input){
+  if (color.length == 9 && color.slice(-2) == "FF") {
+    // if color has hex alpha value -> remove it
+    document.getElementById(input).value = color.slice(0, -2);
+  }
+}
+
+function pickerChange(picker, input) {
+  // color was changed by picker - check it
+  checkColor(picker.toHEXAString(), input);
+}


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. -->

Fixes #136 
* added onChange event to color picker
* Checking if length is 9 and last characters are `FF` -> remove them
* tested initial color and color change for multiple elements

### Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (added a non-breaking change which fixes an issue)
- [x] New feature (added a non-breaking change which adds functionality)
- [ ] Updated documentation (updated the readme, templates, or other repo files)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

<!-- 
If you have changed a feature of the stats cards, please describe the tests you made to verify your changes. 
Changes strictly related to documentation can skip this section.
-->

- [ ] Tested locally with a valid username
- [x] Tested locally with an invalid username
- [ ] Ran tests with `composer test`
- [ ] Added or updated test cases to test new features

## Checklist:

- [x] I have checked to make sure no other [pull requests](https://github.com/DenverCoder1/github-readme-streak-stats/pulls?q=is%3Apr+sort%3Aupdated-desc+) are open for this issue
- [x] The code is properly formatted and is consistent with the existing code style
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Screenshots

![Screenshot_20211001_154815](https://user-images.githubusercontent.com/4334997/135631017-7535e8b4-0995-4c0f-a6d9-66cfb31981eb.png)
no trailling `FF` when color is fully opaque.
