### PR TITLE
fix php warning when no cookie

### DIFF
--- a/src/demo/index.php
+++ b/src/demo/index.php
@@ -28,7 +28,7 @@
     <script async defer src="https://buttons.github.io/buttons.js"></script>
 </head>
 
-<body <?php echo $_COOKIE["darkmode"] == "on" ? 'data-theme="dark"' : ""; ?>>
+<body <?php echo (isset($_COOKIE["darkmode"]) && $_COOKIE["darkmode"] == "on") ? 'data-theme="dark"' : ""; ?>>
     <h1>🔥 GitHub Readme Streak Stats</h1>
 
     <!-- GitHub badges/links section -->


### PR DESCRIPTION
## Description

If there is no cookie at all (e.g. first start) `$_COOKIE["darkmode"]` is not set and there will be a PHP warning (I have them enabled on my local machine)

### Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (added a non-breaking change which fixes an issue)
- [ ] New feature (added a non-breaking change which adds functionality)
- [ ] Updated documentation (updated the readme, templates, or other repo files)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

<!-- 
If you have changed a feature of the stats cards, please describe the tests you made to verify your changes. 
Changes strictly related to documentation can skip this section.
-->

- [ ] Tested locally with a valid username
- [x] Tested locally with an invalid username
- [ ] Ran tests with `composer test`
- [ ] Added or updated test cases to test new features

## Checklist:

- [x] I have checked to make sure no other [pull requests](https://github.com/DenverCoder1/github-readme-streak-stats/pulls?q=is%3Apr+sort%3Aupdated-desc+) are open for this issue
- [x] The code is properly formatted and is consistent with the existing code style
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Screenshots

![Screenshot_20211001_155625](https://user-images.githubusercontent.com/4334997/135632342-f9a7d1a4-38d0-4285-b24c-d9fd27113273.png)

warning will be gone after this PR
