### PR TITLE
Change the jscolor format to HEX instead of HEXA

### DIFF
--- a/src/demo/js/script.js
+++ b/src/demo/js/script.js
@@ -71,12 +71,17 @@ let preview = {
       label.innerText = property;
       label.setAttribute("data-property", property);
       // color picker
+      const jscolorConfig = {
+        format: 'hexa',
+        onChange: 'pickerChange(this, "'+property+'")',
+        onInput: 'pickerChange(this, "'+property+'")'
+      };
       const input = document.createElement("input");
       input.className = "param jscolor";
       input.id = property;
       input.name = property;
       input.setAttribute("data-property", property);
-      input.setAttribute("data-jscolor", "{ format: 'hex', onInput: 'pickerChange(this, \"" + property + "\")' }");
+      input.setAttribute("data-jscolor", JSON.stringify(jscolorConfig));
       input.value = value;
       // removal button
       const minus = document.createElement("button");

--- a/src/demo/js/script.js
+++ b/src/demo/js/script.js
@@ -76,7 +76,7 @@ let preview = {
       input.id = property;
       input.name = property;
       input.setAttribute("data-property", property);
-      input.setAttribute("data-jscolor", "{ format: 'hexa', onInput: 'pickerChange(this, \"" + property + "\")' }");
+      input.setAttribute("data-jscolor", "{ format: 'hex', onInput: 'pickerChange(this, \"" + property + "\")' }");
       input.value = value;
       // removal button
       const minus = document.createElement("button");


### PR DESCRIPTION
## Description

I changed a jscolor configuration where the format was set as HEXA instead of HEX.

Fixes #145 

### Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (added a non-breaking change which fixes an issue)

## How Has This Been Tested?

<!-- 
If you have changed a feature of the stats cards, please describe the tests you made to verify your changes. 
Changes strictly related to documentation can skip this section.
-->

- [x] Tested locally with a valid username
- [ ] Tested locally with an invalid username
- [ ] Ran tests with `composer test`
- [ ] Added or updated test cases to test new features

## Checklist:

- [x] I have checked to make sure no other [pull requests](https://github.com/DenverCoder1/github-readme-streak-stats/pulls?q=is%3Apr+sort%3Aupdated-desc+) are open for this issue
- [x] The code is properly formatted and is consistent with the existing code style
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Screenshots

<!-- If you have updated the design or appearance, please include a screenshot of your changes. -->
