### PR TITLE
Attempt to fix png conversion on Heroku by prepending xml tag

### DIFF
--- a/src/card.php
+++ b/src/card.php
@@ -1,4 +1,6 @@
-<?php declare (strict_types = 1);
+<?php
+
+declare(strict_types=1);
 
 /**
  * Convert date from Y-M-D to more human-readable format
@@ -295,7 +297,8 @@ function generateErrorCard(string $message, array $params = null): string
  *
  * @param string $svg The SVG for the card to display
  */
-function echoAsSvg(string $svg): void {
+function echoAsSvg(string $svg): void
+{
     // set content type to SVG image
     header("Content-Type: image/svg+xml");
 
@@ -310,10 +313,11 @@ function echoAsSvg(string $svg): void {
  *
  * @throws ImagickException
  */
-function echoAsPng(string $svg): void {
+function echoAsPng(string $svg): void
+{
     // trim off all whitespaces to make it a valid SVG string
     $svg = trim($svg);
-
+    
     // remove style and animations
     $svg = preg_replace('/(<style>\X*<\/style>)/m', '', $svg);
     $svg = preg_replace('/(opacity: 0;)/m', 'opacity: 1;', $svg);

--- a/src/card.php
+++ b/src/card.php
@@ -329,7 +329,7 @@ function echoAsPng(string $svg): void
     $imagick->setBackgroundColor(new ImagickPixel('transparent'));
 
     // add svg image
-    $imagick->readImageBlob($svg);
+    $imagick->readImageBlob('<?xml version="1.0" encoding="UTF-8" standalone="no"?>' . $svg);
     $imagick->setImageFormat('png');
 
     // echo PNG data

--- a/src/demo/preview.php
+++ b/src/demo/preview.php
@@ -1,4 +1,6 @@
-<?php declare (strict_types = 1);
+<?php
+
+declare(strict_types=1);
 
 require_once "../card.php";
 

--- a/src/index.php
+++ b/src/index.php
@@ -1,4 +1,6 @@
-<?php declare (strict_types = 1);
+<?php
+
+declare(strict_types=1);
 
 
 // load functions
@@ -15,9 +17,9 @@ $requestedType = $_REQUEST['type'] ?? 'svg';
 
 // if environment variables are not loaded, display error
 if (!$_SERVER["TOKEN"] || !$_SERVER["USERNAME"]) {
-    $message = file_exists(dirname(__DIR__.'.env',1))
-    ? "Missing token or username in config. Check Contributing.md for details."
-    : ".env was not found. Check Contributing.md for details.";
+    $message = file_exists(dirname(__DIR__ . '.env', 1))
+        ? "Missing token or username in config. Check Contributing.md for details."
+        : ".env was not found. Check Contributing.md for details.";
 
     $card = generateErrorCard($message);
     if ($requestedType === "png") {

--- a/src/stats.php
+++ b/src/stats.php
@@ -1,4 +1,6 @@
-<?php declare (strict_types = 1);
+<?php
+
+declare(strict_types=1);
 
 /**
  * Get all HTTP request responses for user's contributions

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -1,4 +1,7 @@
-<?php declare (strict_types = 1);
+<?php
+
+declare(strict_types=1);
+
 use PHPUnit\Framework\TestCase;
 
 // load functions
@@ -56,7 +59,7 @@ final class OptionsTest extends TestCase
         foreach ($themes as $theme => $colors) {
             // check that there are no extra keys in the theme
             $this->assertEquals(
-                array_diff_key($colors, $this->defaultTheme), 
+                array_diff_key($colors, $this->defaultTheme),
                 array(),
                 "The theme '$theme' contains invalid parameters."
             );

--- a/tests/RenderTest.php
+++ b/tests/RenderTest.php
@@ -1,4 +1,7 @@
-<?php declare (strict_types = 1);
+<?php
+
+declare(strict_types=1);
+
 use PHPUnit\Framework\TestCase;
 
 // load functions

--- a/tests/StatsTest.php
+++ b/tests/StatsTest.php
@@ -1,8 +1,11 @@
-<?php declare (strict_types = 1);
+<?php
+
+declare(strict_types=1);
+
 use PHPUnit\Framework\TestCase;
 
 // load functions
-require_once dirname(__DIR__, 1).'/vendor/autoload.php';
+require_once dirname(__DIR__, 1) . '/vendor/autoload.php';
 require_once "src/stats.php";
 
 // load .env
@@ -13,8 +16,8 @@ $dotenv->safeLoad();
 // if environment variables are not loaded, display error
 if (!$_SERVER["TOKEN"] || !$_SERVER["USERNAME"]) {
     $message = file_exists(dirname(__DIR__ . '.env', 1))
-    ? "Missing token or username in config. Check Contributing.md for details."
-    : ".env was not found. Check Contributing.md for details.";
+        ? "Missing token or username in config. Check Contributing.md for details."
+        : ".env was not found. Check Contributing.md for details.";
 
     die($message);
 }


### PR DESCRIPTION
## Description

Attempt to fix png conversion on Heroku by prepending xml tag

Solution found here:

Fixes #149 

### Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (added a non-breaking change which fixes an issue)
- [ ] New feature (added a non-breaking change which adds functionality)
- [ ] Updated documentation (updated the readme, templates, or other repo files)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

<!-- 
If you have changed a feature of the stats cards, please describe the tests you made to verify your changes. 
Changes strictly related to documentation can skip this section.
-->

- [x] Tested locally with a valid username
- [x] Tested locally with an invalid username
- [x] Ran tests with `composer test`
- [ ] Added or updated test cases to test new features

## Checklist:

- [x] I have checked to make sure no other [pull requests](https://github.com/DenverCoder1/github-readme-streak-stats/pulls?q=is%3Apr+sort%3Aupdated-desc+) are open for this issue
- [x] The code is properly formatted and is consistent with the existing code style
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Screenshots

<!-- If you have updated the design or appearance, please include a screenshot of your changes. -->
