### PR TITLE
Error handling for getGitHubApiResponse

### DIFF
--- a/src/stats.php
+++ b/src/stats.php
@@ -110,9 +110,8 @@ function getGitHubApiResponse(string $url): string
     $response = curl_exec($ch);
 
     //Handles curl errors
-    if($response==false){
-        if(str_contains(curl_error($ch),'unable to get local issuer certificate'))
-        {
+    if($response === false) {
+        if(str_contains(curl_error($ch), 'unable to get local issuer certificate')) {
             throw new InvalidArgumentException("You don't have valid SSL Certificate installed or XAMPP.");
         }
         throw new InvalidArgumentException("Something is wrong with getGitHubApiResponse().");

--- a/src/stats.php
+++ b/src/stats.php
@@ -114,6 +114,7 @@ function getGitHubApiResponse(string $url): string
         {
             throw new InvalidArgumentException("You don't have valid SSL Certificate installed or XAMPP.");
         }
+        throw new InvalidArgumentException("Something is wrong with getGitHubApiResponse().");
     }
 
     curl_close($ch);

--- a/src/stats.php
+++ b/src/stats.php
@@ -108,6 +108,14 @@ function getGitHubApiResponse(string $url): string
     curl_setopt($ch, CURLOPT_VERBOSE, false);
     curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
     $response = curl_exec($ch);
+
+    if($response==false){
+        if(str_contains(curl_error($ch),'unable to get local issuer certificate'))
+        {
+            throw new InvalidArgumentException("You don't have valid SSL Certificate installed or XAMPP.");
+        }
+    }
+
     curl_close($ch);
     return $response;
 }

--- a/src/stats.php
+++ b/src/stats.php
@@ -109,6 +109,7 @@ function getGitHubApiResponse(string $url): string
     curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
     $response = curl_exec($ch);
 
+    //Handles curl errors
     if($response==false){
         if(str_contains(curl_error($ch),'unable to get local issuer certificate'))
         {


### PR DESCRIPTION
## Description

IF it's bool false, then throws an error. If has a specific string from an SSL error certificate, throws a different exception.
Fixes #157

### Type of change


- [X] New feature (added a non-breaking change which adds functionality)

## How Has This Been Tested?

- [ ] Tested locally with a valid username
- [ ] Tested locally with an invalid username
- [X] Ran tests with `composer test`
- [ ] Added or updated test cases to test new features

## Checklist:

- [X] I have checked to make sure no other [pull requests](https://github.com/DenverCoder1/github-readme-streak-stats/pulls?q=is%3Apr+sort%3Aupdated-desc+) are open for this issue
- [X] The code is properly formatted and is consistent with the existing code style
- [X] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings


