### PR TITLE
Force Imagick to interpret the blob as an SVG

### DIFF
--- a/src/card.php
+++ b/src/card.php
@@ -317,7 +317,7 @@ function echoAsPng(string $svg): void
 {
     // trim off all whitespaces to make it a valid SVG string
     $svg = trim($svg);
-    
+
     // remove style and animations
     $svg = preg_replace('/(<style>\X*<\/style>)/m', '', $svg);
     $svg = preg_replace('/(opacity: 0;)/m', 'opacity: 1;', $svg);
@@ -329,8 +329,9 @@ function echoAsPng(string $svg): void
     $imagick->setBackgroundColor(new ImagickPixel('transparent'));
 
     // add svg image
+    $imagick->setFormat('svg');
     $imagick->readImageBlob('<?xml version="1.0" encoding="UTF-8" standalone="no"?>' . $svg);
-    $imagick->setImageFormat('png');
+    $imagick->setFormat('png');
 
     // echo PNG data
     header('Content-Type: image/png');


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. -->
This PR will force Imagick to interpet the given SVG as an SVG instead of it trying to understand what it is.

Fixes #149

### Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (added a non-breaking change which fixes an issue)

## How Has This Been Tested?

<!-- 
If you have changed a feature of the stats cards, please describe the tests you made to verify your changes. 
Changes strictly related to documentation can skip this section.
-->

- [x] Tested locally with a valid username
- [ ] Tested locally with an invalid username
- [ ] Ran tests with `composer test`
- [ ] Added or updated test cases to test new features

## Checklist:

- [x] I have checked to make sure no other [pull requests](https://github.com/DenverCoder1/github-readme-streak-stats/pulls?q=is%3Apr+sort%3Aupdated-desc+) are open for this issue
- [x] The code is properly formatted and is consistent with the existing code style
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Screenshots

<!-- If you have updated the design or appearance, please include a screenshot of your changes. -->
