### PR TITLE
Change output errors as JSON when type set to json

### DIFF
--- a/src/index.php
+++ b/src/index.php
@@ -19,6 +19,14 @@ if (!$_SERVER["TOKEN"] || !$_SERVER["USERNAME"]) {
     ? "Missing token or username in config. Check Contributing.md for details."
     : ".env was not found. Check Contributing.md for details.";
 
+    if ($requestedType === "json") {
+        // set content type to JSON
+        header('Content-Type: application/json');
+        // echo JSON error message
+        echo json_encode(array("error" => $message));
+        exit;
+    }
+    
     $card = generateErrorCard($message);
     if ($requestedType === "png") {
         echoAsPng($card);
@@ -52,7 +60,7 @@ try {
         // set content type to JSON
         header('Content-Type: application/json');
         // echo JSON error message
-        echo json_encode(array("error"=>"User could not be found."));
+        echo json_encode(array("error" => $error->getMessage()));
         exit;
     }
     $card = generateErrorCard($error->getMessage());

--- a/src/index.php
+++ b/src/index.php
@@ -48,6 +48,13 @@ try {
     $contributions = getContributionDates($contributionGraphs);
     $stats = getContributionStats($contributions);
 } catch (InvalidArgumentException $error) {
+    if ($requestedType === "json") {
+        // set content type to JSON
+        header('Content-Type: application/json');
+        // echo JSON error message
+        echo json_encode(array("error"=>"User could not be found."));
+        exit;
+    }
     $card = generateErrorCard($error->getMessage());
     if ($requestedType === "png") {
         echoAsPng($card);


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. -->

Fixes #141 <!-- add issue number -->

This PR changes the output error to JSON when there is an error and the type is set to json:
```
{
"error": "User could not be found."
}
```
### Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (added a non-breaking change which fixes an issue)
- [ ] New feature (added a non-breaking change which adds functionality)
- [ ] Updated documentation (updated the readme, templates, or other repo files)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

<!-- 
If you have changed a feature of the stats cards, please describe the tests you made to verify your changes. 
Changes strictly related to documentation can skip this section.
-->

- [x] Tested locally with a valid username
- [x] Tested locally with an invalid username
- [x] Ran tests with `composer test`
- [ ] Added or updated test cases to test new features

## Checklist:

- [x] I have checked to make sure no other [pull requests](https://github.com/DenverCoder1/github-readme-streak-stats/pulls?q=is%3Apr+sort%3Aupdated-desc+) are open for this issue
- [x] The code is properly formatted and is consistent with the existing code style
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Screenshots

<!-- If you have updated the design or appearance, please include a screenshot of your changes. -->
