### PR TITLE
fix: Updates to cache control

### DIFF
--- a/src/index.php
+++ b/src/index.php
@@ -22,13 +22,10 @@ if (!$_SERVER["TOKEN"] || !$_SERVER["USERNAME"]) {
     renderOutput($message);
 }
 
-
-// set cache to refresh once per day
-$timestamp = gmdate("D, d M Y 23:59:00") . " GMT";
-header("Expires: $timestamp");
-header("Last-Modified: $timestamp");
-header("Pragma: no-cache");
-header("Cache-Control: no-cache, must-revalidate");
+// set cache to refresh once per hour
+header("Expires: " . gmdate("D, d M Y H:i:s", time() + 3600) . " GMT");
+header("Last-Modified: " . gmdate("D, d M Y H:i:s") . " GMT");
+header("Cache-Control: public, max-age=3600");
 
 // redirect to demo site if user is not given
 if (!isset($_REQUEST["user"])) {
@@ -46,6 +43,6 @@ try {
     }
     $stats = getContributionStats($contributions);
     renderOutput($stats);
-} catch (InvalidArgumentException|AssertionError $error) {
+} catch (InvalidArgumentException | AssertionError $error) {
     renderOutput($error->getMessage());
 }


### PR DESCRIPTION
## Description

Updated cache control to allow full caching for up to an hour. Hopefully this should reduce the number of requests made to GitHub and avoid the "No contributions found" error.

Should fix #169 

### Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (added a non-breaking change which fixes an issue)
- [ ] New feature (added a non-breaking change which adds functionality)
- [ ] Updated documentation (updated the readme, templates, or other repo files)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

<!-- 
If you have changed a feature of the stats cards, please describe the tests you made to verify your changes. 
Changes strictly related to documentation can skip this section.
-->

- [x] Tested locally with a valid username
- [x] Tested locally with an invalid username
- [x] Ran tests with `composer test`
- [ ] Added or updated test cases to test new features

## Checklist:

- [x] I have checked to make sure no other [pull requests](https://github.com/DenverCoder1/github-readme-streak-stats/pulls?q=is%3Apr+sort%3Aupdated-desc+) are open for this issue
- [x] The code is properly formatted and is consistent with the existing code style
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Screenshots

<!-- If you have updated the design or appearance, please include a screenshot of your changes. -->
