### PR TITLE
Add button for exporting a theme from the demo site

### DIFF
--- a/src/demo/index.php
+++ b/src/demo/index.php
@@ -97,6 +97,8 @@
                         <button class="plus btn" onclick="return preview.addProperty();">+</button>
                     </div>
                 </details>
+                <button class="btn" type="button" onclick='return exportPhp()'>button</button>
+                <textarea id="test"></textarea>
 
                 <input class="btn" type="submit" value="Submit">
             </form>

--- a/src/demo/js/script.js
+++ b/src/demo/js/script.js
@@ -12,7 +12,7 @@ let preview = {
         let obj = { ...acc };
         let value = next.value;
 
-        if (value.indexOf('#') >= 0) {
+        if (value.indexOf("#") >= 0) {
           // if the value is colour, remove the hash sign
           value = value.replace(/#/g, "");
           if (value.length > 6) {
@@ -72,9 +72,9 @@ let preview = {
       label.setAttribute("data-property", property);
       // color picker
       const jscolorConfig = {
-        format: 'hexa',
-        onChange: 'pickerChange(this, "'+property+'")',
-        onInput: 'pickerChange(this, "'+property+'")'
+        format: "hexa",
+        onChange: 'pickerChange(this, "' + property + '")',
+        onInput: 'pickerChange(this, "' + property + '")',
       };
       const input = document.createElement("input");
       input.className = "param jscolor";
@@ -179,8 +179,55 @@ window.addEventListener(
   },
   false
 );
+function exportPhp() {
+  let properties = [
+    "border",
+    "stroke",
+    "ring",
+    "fire",
+    "currStreakNum",
+    "sideNums",
+    "currStreakLabel",
+    "sideLabels",
+    "dates",
+    "background",
+  ];
+  let array = Array.from(document.querySelectorAll(".param")).reduce(
+    (acc, next) => {
+      let obj = { ...acc };
+      let value = next.value;
+      if (value.indexOf("#") >= 0) {
+        // if the value is colour, remove the hash sign
+        value = value.replace(/#/g, "");
+        if (value.length > 6) {
+          // if the value is in hexa and opacity is 1, remove FF
+          value = value.replace(/(F|f){2}$/, "");
+        }
+      }
+      obj[next.id] = value;
+      return obj;
+    },
+    {}
+  );
+  var exportPhp = {};
 
-function checkColor(color, input){
+  for (const [key, val] of Object.entries(array)) {
+    if (properties.includes(key) > 0) {
+      exportPhp[key] = val;
+    }
+  }
+
+  const output =
+    "[\n" +
+    Object.keys(exportPhp)
+      .map((key) => `\t"${key}" => "#${exportPhp[key]}",\n`)
+      .join("") +
+    "]";
+  document.getElementById('test').value = output;
+  console.log(output);
+}
+
+function checkColor(color, input) {
   if (color.length == 9 && color.slice(-2) == "FF") {
     // if color has hex alpha value -> remove it
     document.getElementById(input).value = color.slice(0, -2);


### PR DESCRIPTION
## Description

Hey! I created this working solution, please let me know if it's appropriated. This is not a **final solution**.

I created json_decode.php file so JS sends the properties json and php exports it to the text area.
It was the only working solution that I could make it work.
HTML and CSS is not final, please let me know where you want me to export it.

Let me know what changes I can make and if I'm going the right path.

Fixes #144

### Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (added a non-breaking change which fixes an issue)
- [X] New feature (added a non-breaking change which adds functionality)
- [ ] Updated documentation (updated the readme, templates, or other repo files)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

<!-- 
If you have changed a feature of the stats cards, please describe the tests you made to verify your changes. 
Changes strictly related to documentation can skip this section.
-->

- [X] Tested locally with a valid username
- [X] Tested locally with an invalid username
- [ ] Ran tests with `composer test`
- [ ] Added or updated test cases to test new features

## Checklist:

- [X] I have checked to make sure no other [pull requests](https://github.com/DenverCoder1/github-readme-streak-stats/pulls?q=is%3Apr+sort%3Aupdated-desc+) are open for this issue
- [X] The code is properly formatted and is consistent with the existing code style
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X ] My changes generate no new warnings

## Screenshots

![image](https://user-images.githubusercontent.com/59452877/135757054-a6a4443f-d893-42e5-ad17-51e9456095f0.png)
