### PR TITLE
fix: Migration to GraphQL API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,2 @@
-TOKEN=
-USERNAME=
+# replace ghp_example with your GitHub PAT token
+TOKEN=ghp_example

--- a/.github/workflows/phpunit-ci-coverage.yml
+++ b/.github/workflows/phpunit-ci-coverage.yml
@@ -23,4 +23,3 @@ jobs:
           args: --testdox
         env:
           TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          USERNAME: DenverCoder1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,16 +51,12 @@ cd github-readme-streak-stats
 
 To get the GitHub API to run locally you will need to provide a token.
 
-1. Go to https://github.com/settings/tokens.
-2. Click **"Generate new token."**
-3. Add a note (ex. **"GitHub Readme Streak Stats"**), then scroll to the bottom and click **"Generate token."**
-4. **Copy** the token to your clipboard.
-5. **Create** a file `config.php` in the `src` directory and replace `ghp_example123` with **your token** and `DenverCoder1` with **your username**:
+1. Visit [this link](https://github.com/settings/tokens/new?description=GitHub%20Readme%20Streak%20Stats) to create a new Personal Access Token
+2. Scroll to the bottom and click **"Generate token"**
+3. **Make a copy** of `.env.example` named `.env` in the root directory and add **your token** after `TOKEN=`.
 
 ```php
-<?php
-putenv("TOKEN=ghp_example123");
-putenv("USERNAME=DenverCoder1");
+TOKEN=<your-token>
 ```
 
 ### Install dependencies

--- a/README.md
+++ b/README.md
@@ -226,11 +226,10 @@ To get the GitHub API to run locally you will need to provide a token.
 
 1. Visit [this link](https://github.com/settings/tokens/new?description=GitHub%20Readme%20Streak%20Stats) to create a new Personal Access Token
 2. Scroll to the bottom and click **"Generate token"**
-3. **Make a copy** of `.env.example` named `.env` in the root directory and add **your token** after `TOKEN=` and **your username** after `USERNAME=`:
+3. **Make a copy** of `.env.example` named `.env` in the root directory and add **your token** after `TOKEN=`:
 
 ```php
-TOKEN=
-USERNAME=
+TOKEN=<your-token>
 ```
 
 ### Running the app locally

--- a/app.json
+++ b/app.json
@@ -9,10 +9,6 @@
     "TOKEN": {
       "description": "GitHub personal access token obtained from https://github.com/settings/tokens/new",
       "required": false
-    },
-    "USERNAME": {
-      "description": "GitHub username associated with the token",
-      "required": false
     }
   },
   "formation": {

--- a/src/index.php
+++ b/src/index.php
@@ -14,11 +14,10 @@ $dotenv = \Dotenv\Dotenv::createImmutable(dirname(__DIR__, 1));
 $dotenv->safeLoad();
 
 // if environment variables are not loaded, display error
-if (!$_SERVER["TOKEN"] || !$_SERVER["USERNAME"]) {
-    $message = file_exists(dirname(__DIR__ . '.env', 1))
-        ? "Missing token or username in config. Check Contributing.md for details."
+if (!isset($_SERVER["TOKEN"])) {
+    $message = file_exists(dirname(__DIR__ . '../.env', 1))
+        ? "Missing token in config. Check Contributing.md for details."
         : ".env was not found. Check Contributing.md for details.";
-
     renderOutput($message);
 }
 

--- a/tests/StatsTest.php
+++ b/tests/StatsTest.php
@@ -14,9 +14,9 @@ $dotenv->safeLoad();
 
 
 // if environment variables are not loaded, display error
-if (!$_SERVER["TOKEN"] || !$_SERVER["USERNAME"]) {
-    $message = file_exists(dirname(__DIR__ . '.env', 1))
-        ? "Missing token or username in config. Check Contributing.md for details."
+if (!isset($_SERVER["TOKEN"])) {
+    $message = file_exists(dirname(__DIR__ . '../.env', 1))
+        ? "Missing token in config. Check Contributing.md for details."
         : ".env was not found. Check Contributing.md for details.";
 
     die($message);
@@ -67,7 +67,7 @@ final class StatsTest extends TestCase
     public function testInvalidUsername(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage("User could not be found.");
+        $this->expectExceptionMessage("Could not find a user with that name.");
         getContributionGraphs("help");
     }
 
@@ -77,7 +77,7 @@ final class StatsTest extends TestCase
     public function testOrganizationName(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage("The username given is not a user.");
+        $this->expectExceptionMessage("Could not find a user with that name.");
         getContributionGraphs("DenverCoderOne");
     }
 
@@ -206,10 +206,38 @@ final class StatsTest extends TestCase
         $tomorrow = date('Y-m-d', strtotime('tomorrow'));
         $inTwoDays = date('Y-m-d', strtotime("$today +2 days"));
         $contributionGraphs = [
-            "<rect width=\"10\" height=\"10\" x=\"-2\" y=\"13\" class=\"ContributionCalendar-day\" rx=\"2\" ry=\"2\" data-count=\"1\" data-date=\"$yesterday\" data-level=\"1\"></rect>
-            <rect width=\"10\" height=\"10\" x=\"-2\" y=\"26\" class=\"ContributionCalendar-day\" rx=\"2\" ry=\"2\" data-count=\"1\" data-date=\"$today\" data-level=\"2\"></rect>
-            <rect width=\"10\" height=\"10\" x=\"-2\" y=\"39\" class=\"ContributionCalendar-day\" rx=\"2\" ry=\"2\" data-count=\"1\" data-date=\"$tomorrow\" data-level=\"0\"></rect>
-            <rect width=\"10\" height=\"10\" x=\"-2\" y=\"52\" class=\"ContributionCalendar-day\" rx=\"2\" ry=\"2\" data-count=\"1\" data-date=\"$inTwoDays\" data-level=\"0\"></rect>",
+            (object) [
+                "data" => (object) [
+                    "user" => (object) [
+                        "contributionsCollection" => (object) [
+                            "contributionCalendar" => (object) [
+                                "weeks" => (object) [
+                                    (object) [
+                                        "contributionDays" => (object) [
+                                            (object) [
+                                                "contributionCount" => 1,
+                                                "date" => $yesterday,
+                                            ],
+                                            (object) [
+                                                "contributionCount" => 1,
+                                                "date" => $today,
+                                            ],
+                                            (object) [
+                                                "contributionCount" => 1,
+                                                "date" => $tomorrow,
+                                            ],
+                                            (object) [
+                                                "contributionCount" => 1,
+                                                "date" => $inTwoDays,
+                                            ],
+                                        ],
+                                    ]
+                                ]
+                            ]
+                        ],
+                    ],
+                ]
+            ]
         ];
         $contributions = getContributionDates($contributionGraphs);
         $stats = getContributionStats($contributions);


### PR DESCRIPTION
## Description

Migrates from using undocumented contribution graph SVG endpoints to using the GitHub API v4 (GraphQL) to get the dates containing contributions.

This should hopefully make the cards work more reliably and reduce rate-limiting issues.

### Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (added a non-breaking change which fixes an issue)
- [ ] New feature (added a non-breaking change which adds functionality)
- [x] Updated documentation (updated the readme, templates, or other repo files)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

<!-- 
If you have changed a feature of the stats cards, please describe the tests you made to verify your changes. 
Changes strictly related to documentation can skip this section.
-->

- [x] Tested locally with a valid username
- [x] Tested locally with an invalid username
- [x] Ran tests with `composer test`
- [x] Added or updated test cases to test new features

## Checklist:

- [x] I have checked to make sure no other [pull requests](https://github.com/DenverCoder1/github-readme-streak-stats/pulls?q=is%3Apr+sort%3Aupdated-desc+) are open for this issue
- [x] The code is properly formatted and is consistent with the existing code style
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
