### PR TITLE
Fix tests when current streak is 0

### DIFF
--- a/tests/StatsTest.php
+++ b/tests/StatsTest.php
@@ -56,9 +56,15 @@ final class StatsTest extends TestCase
         // test length of longest streak matches time between start and end dates
         $longestStreakDelta = strtotime($stats["longestStreak"]["end"]) - strtotime($stats["longestStreak"]["start"]);
         $this->assertEquals($longestStreakDelta / 60 / 60 / 24 + 1, $stats["longestStreak"]["length"]);
+        // if the current streak is 0, the start date should be the same as the end date
+        if ($stats["currentStreak"]["length"] == 0) {
+            $this->assertEquals($stats["currentStreak"]["start"], $stats["currentStreak"]["end"]);
+        }
         // test length of current streak matches time between start and end dates
-        $currentStreakDelta = strtotime($stats["currentStreak"]["end"]) - strtotime($stats["currentStreak"]["start"]);
-        $this->assertEquals($currentStreakDelta / 60 / 60 / 24 + 1, $stats["currentStreak"]["length"]);
+        else {
+            $currentStreakDelta = strtotime($stats["currentStreak"]["end"]) - strtotime($stats["currentStreak"]["start"]);
+            $this->assertEquals($currentStreakDelta / 60 / 60 / 24 + 1, $stats["currentStreak"]["length"]);
+        }
     }
 
     /**


### PR DESCRIPTION
## Description

Valid username test fails when current streak is 0 since start - end is 1 day, but both 0 and 1 are possible streak lengths.