### PR TITLE
feat: Add github-green-purple theme

### DIFF
--- a/docs/themes/README.md
+++ b/docs/themes/README.md
@@ -81,6 +81,7 @@ You can also try out and customize these themes on the [Demo Site](https://githu
 |      `navy-gear`       | ![image](https://user-images.githubusercontent.com/20955511/153954354-60438cfa-d0a0-4737-936c-65b61faf637d.png) |
 |      `hacker`          | ![image](https://user-images.githubusercontent.com/20955511/164965194-724816b5-5aa0-4c36-8bae-f3cbafd2c2a4.png) |
 |      `garden`          | ![image](https://user-images.githubusercontent.com/44000014/165035015-153d9b3a-bd3a-4e34-b252-3c64ab081b75.png) |
+|  `github-green-purple` | ![image](https://user-images.githubusercontent.com/20955511/173238945-f572fdfb-dbf6-4141-8ee6-b70f6186548e.png)  |
 ### Can't find the theme you like?
 
 You can now customize your stats card with the interactive [Demo Site](https://github-readme-streak-stats.herokuapp.com/demo/) or by customizing the [url parameters](/README.md#-options).

--- a/src/themes.php
+++ b/src/themes.php
@@ -902,4 +902,16 @@ return [
         "sideLabels" => "#6FDD6C",
         "dates" => "#6FDD6C",
     ],
+    "github-green-purple" => [
+        "background" => "#000",
+        "border" => "#000",
+        "stroke" => "#e4e2e2",
+        "ring" => "#7fff00",
+        "fire" => "#7fff00",
+        "currStreakNum" => "#800080",
+        "sideNums" => "#7fff00",
+        "currStreakLabel" => "#800080",
+        "sideLabels" => "#7fff00",
+        "dates" => "#fff",
+    ],
 ];


### PR DESCRIPTION
This theme  is suitable for dark theme github, with green purple colors and white text for info.

## Description

<!-- Please include a summary of the change and which issue is fixed. -->

Fixes # <!-- add issue number -->

### Type of change

<!-- Please delete options that are not relevant. -->

- [x] Updated documentation (updated the readme, templates, or other repo files)

## How Has This Been Tested?

<!-- 
If you have changed a feature of the stats cards, please describe the tests you made to verify your changes. 
Changes strictly related to documentation can skip this section.
-->

- [x] Tested with a valid username
- [x] Tested with an invalid username

## Checklist:

- [x] I have checked to make sure no other [pull requests](https://github.com/DenverCoder1/github-readme-streak-stats/pulls?q=is%3Apr+sort%3Aupdated-desc+) are open for this issue
- [x] The code is properly formatted and is consistent with the existing code style
- [x] I have commented my code, particularly in hard-to-understand areas
 - [x] My changes generate no new warnings
- [x] I have made corresponding changes to the documentation

## Screenshots

<!-- If you have updated the design or appearance, please include a screenshot of your changes. -->
![image](https://user-images.githubusercontent.com/70573212/173237183-b4f9397f-9a34-4930-b12c-8ff94ee66bd3.png)

