### PR TITLE
Update Portuguese translations

### DIFF
--- a/src/translations.php
+++ b/src/translations.php
@@ -51,7 +51,7 @@ return [
         "Total Contributions" => "Total de Contribuições",
         "Current Streak" => "Atual Sequência",
         "Longest Streak" => "Maior Sequência",
-        "Present" => "Atualmente",
+        "Present" => "Presente",
     ],
     "tr" => [
         "Total Contributions" => "Toplam Katkı",


### PR DESCRIPTION
The word "Atualmente" was too big, the translation "Presente" is the same meaning, it's just not used much in São Paulo.

- [X] Bug fix (added a non-breaking change which fixes an issue)

## Screenshots

![image](https://user-images.githubusercontent.com/63819830/173971559-21d41461-bd23-46ea-a4d6-633c4f29f1a4.png)
