### PR TITLE
Add Korean Translation

### DIFF
--- a/src/translations.php
+++ b/src/translations.php
@@ -59,6 +59,12 @@ return [
         "Longest Streak" => "最長のストリーク",
         "Present" => "今",
     ],
+    "ko" => [
+        "Total Contributions" => "총 컨트리뷰트 수",
+        "Current Streak" => "현재 연속 커밋 수",
+        "Longest Streak" => "최대 연속 커밋 수",
+        "Present" => "현재",
+    ],
     "nl" => [
         "Total Contributions" => "Totale Bijdrage",
         "Current Streak" => "Huidige Serie",


### PR DESCRIPTION
## Description

I'm adding a translation for a Korean developer. 
I am also a Korean developer.
I translated it because Korean developers love the project so much. Thank you. 🙏

I interpreted the word "Streak" as "work that I've been doing." 
So I translated 'Current Streak' into 'Current Continuous Commit Count' and 'Longest Streak' into 'Maximum Continuous Commit Count'.

Fixes #236 

### Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (added a non-breaking change which fixes an issue)
- [ ] New feature (added a non-breaking change which adds functionality)
- [ ] Updated documentation (updated the readme, templates, or other repo files)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

<!--
If you have changed a feature of the stats cards, please describe the tests you made to verify your changes.
Changes strictly related to documentation can skip this section.
-->

- [x] Tested locally with a valid username
- [x] Tested locally with an invalid username
- [x] Ran tests with `composer test`
- [ ] Added or updated test cases to test new features

## Checklist:

- [x] I have checked to make sure no other [pull requests](https://github.com/DenverCoder1/github-readme-streak-stats/pulls?q=is%3Apr+sort%3Aupdated-desc+) are open for this issue
- [x] The code is properly formatted and is consistent with the existing code style
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Screenshots
<img width="819" alt="스크린샷 2022-07-05 오후 10 57 42" src="https://user-images.githubusercontent.com/10377550/177344989-51bccdf2-65aa-4212-af02-c3346bae30bb.png">

