### PR TITLE
feat: Add neon_blurange theme

### DIFF
--- a/docs/themes/README.md
+++ b/docs/themes/README.md
@@ -83,6 +83,7 @@ You can also try out and customize these themes on the [Demo Site](https://githu
 |        `garden`        | ![image](https://user-images.githubusercontent.com/20955511/177458181-5c2242f0-1c89-4de0-9965-28c777f9f8d7.png) |
 | `github-green-purple`  | ![image](https://user-images.githubusercontent.com/20955511/173238945-f572fdfb-dbf6-4141-8ee6-b70f6186548e.png) |
 |       `icegray`        | ![image](https://user-images.githubusercontent.com/20955511/177644018-cb9953d0-31a1-4920-a66f-8c08672cec38.png) |
+|    `neon_blurange`     | ![image](https://user-images.githubusercontent.com/45172775/180076569-3af18421-56f5-49bd-b62e-2dec8edc0502.png) |
 
 ### Can't find the theme you like?
 

--- a/src/themes.php
+++ b/src/themes.php
@@ -926,4 +926,16 @@ return [
         "sideLabels" => "#515151",
         "dates" => "#636363",
     ],
+    "neon_blurange" => [
+        "background" => "#030D6B",
+        "border" => "#C7CCFF",
+        "stroke" => "#C7CCFF",
+        "ring" => "#FB750B",
+        "fire" => "#FB750B",
+        "currStreakNum" => "#25FB88",
+        "sideNums" => "#FB750B",
+        "currStreakLabel" => "#25FB88",
+        "sideLabels" => "#25FB88",
+        "dates" => "#C7CCFF",
+    ],
 ];


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. -->
- Add color scheme of `neon_blurange` theme to `themes.php`
- Add `neon_bluerange` to `docs/themes/README.md`

### Issue Link
Closes #278 

### Type of change

<!-- Please delete options that are not relevant. -->

- [x] Updated documentation (updated the readme, templates, or other repo files)

## Checklist:

- [x] I have checked to make sure no other [pull requests](https://github.com/DenverCoder1/github-readme-streak-stats/pulls?q=is%3Apr+sort%3Aupdated-desc+) are open for this issue
- [x] The code is properly formatted and is consistent with the existing code style
- [x] My changes generate no new warnings

## Screenshots
![neon_blurange_70](https://user-images.githubusercontent.com/45172775/180078405-0b46b0a4-5cad-4d6e-9001-fa4e8d2983c9.png)


<!-- If you have updated the design or appearance, please include a screenshot of your changes. -->
