### PR TITLE
feat: add java-dark theme

### DIFF
--- a/docs/themes/README.md
+++ b/docs/themes/README.md
@@ -85,6 +85,7 @@ You can also try out and customize these themes on the [Demo Site](https://githu
 |       `icegray`        | ![image](https://user-images.githubusercontent.com/20955511/177644018-cb9953d0-31a1-4920-a66f-8c08672cec38.png)  |
 |    `neon_blurange`     | ![image](https://user-images.githubusercontent.com/45172775/180076569-3af18421-56f5-49bd-b62e-2dec8edc0502.png)  |
 |      `yellowdark`      | ![image](https://user-images.githubusercontent.com/103951737/180445402-360653bf-b85d-4e53-a1e1-cbda4135326b.png) |
+|      `java-dark`       | ![image](https://user-images.githubusercontent.com/103951737/180605906-b04afca3-da60-4ad9-95d3-8be5ef0a96e3.png) |
 
 ### Can't find the theme you like?
 

--- a/src/themes.php
+++ b/src/themes.php
@@ -950,4 +950,16 @@ return [
         "sideLabels" => "#FFEF00",
         "dates" => "#A5A5A5",
     ],
+    "java-dark" => [
+        "background" => "#000000",
+        "border" => "#F89820",
+        "stroke" => "#F89820",
+        "ring" => "#F89820",
+        "fire" => "#F89820",
+        "currStreakNum" => "#5382A1",
+        "sideNums" => "#5382A1",
+        "currStreakLabel" => "#F89820",
+        "sideLabels" => "#F89820",
+        "dates" => "#5382A1",
+    ],
 ];


### PR DESCRIPTION
## Description

Added new java-dark theme.
The black color and the colors of the Java logo were used.

### Type of change

- [x] Updated documentation (updated the readme, templates, or other repo files)

## How Has This Been Tested?

- [x] Tested locally with a valid username
- [x] Tested locally with an invalid username
- [x] Ran tests with `composer test`
- [x] Added or updated test cases to test new features

## Checklist:

- [x] I have checked to make sure no other [pull requests](https://github.com/DenverCoder1/github-readme-streak-stats/pulls?q=is%3Apr+sort%3Aupdated-desc+) are open for this issue
- [x] The code is properly formatted and is consistent with the existing code style
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Screenshots
###  With border
![image](https://user-images.githubusercontent.com/103951737/180606090-7ad6ed6a-cfee-44a5-8916-fc04bf2a995f.png)
### Without border
![image](https://user-images.githubusercontent.com/103951737/180606096-4007cf12-c472-4a34-8cec-065cac7b402e.png)
