### PR TITLE
fix: Wrong year displayed on cards

### DIFF
--- a/src/card.php
+++ b/src/card.php
@@ -39,7 +39,7 @@ function formatDate(string $dateString, string|null $format, string $locale): st
             $formatted = date_format($date, str_replace(["[", "]"], "", $format));
         } else {
             // format with year using locale
-            $pattern = $patternGenerator->getBestPattern("YYYY MMM d");
+            $pattern = $patternGenerator->getBestPattern("yyyy MMM d");
             $dateFormatter = new IntlDateFormatter(
                 $locale,
                 IntlDateFormatter::MEDIUM,


### PR DESCRIPTION
## Description

Apparently `YYYY` means "Year of 'week of year'" (whatever that means) and this should be using `yyyy` instead.

Fixes #291 

### Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (added a non-breaking change which fixes an issue)
- [ ] New feature (added a non-breaking change which adds functionality)
- [ ] Updated documentation (updated the readme, templates, or other repo files)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

<!--
If you have changed a feature of the stats cards, please describe the tests you made to verify your changes.
Changes strictly related to documentation can skip this section.
-->

- [x] Tested locally with a valid username
- [x] Tested locally with an invalid username
- [x] Ran tests with `composer test`
- [ ] Added or updated test cases to test new features

## Checklist:

- [x] I have checked to make sure no other [pull requests](https://github.com/DenverCoder1/github-readme-streak-stats/pulls?q=is%3Apr+sort%3Aupdated-desc+) are open for this issue
- [x] The code is properly formatted and is consistent with the existing code style
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

## Screenshots

<!-- If you have updated the design or appearance, please include a screenshot of your changes. -->

![image](https://user-images.githubusercontent.com/20955511/183090387-c391bd87-52c8-4eed-8160-c52fbd40aecf.png)

