### PR TITLE
fix(demo): Move locale above date format

### DIFF
--- a/src/demo/index.php
+++ b/src/demo/index.php
@@ -102,6 +102,16 @@ function camel_to_skewer(string $str): string
                     <option>true</option>
                 </select>
 
+                <label for="locale">Locale</label>
+                <select class="param" id="locale" name="locale">
+                    <?php foreach ($LOCALES as $locale): ?>
+                        <option value="<?php echo $locale; ?>">
+                            <?php $display = Locale::getDisplayLanguage($locale, $locale); ?>
+                            <?php echo $display . " (" . $locale . ")"; ?>
+                        </option>
+                    <?php endforeach; ?>
+                </select>
+
                 <label for="date_format">Date Format</label>
                 <select class="param" id="date_format" name="date_format">
                     <option value="">default</option>
@@ -111,16 +121,6 @@ function camel_to_skewer(string $str): string
                     <option value="j/n[/Y]">10/8/2016</option>
                     <option value="n/j[/Y]">8/10/2016</option>
                     <option value="[Y.]n.j">2016.8.10</option>
-                </select>
-
-                <label for="locale">Locale</label>
-                <select class="param" id="locale" name="locale">
-                    <?php foreach ($LOCALES as $locale): ?>
-                        <option value="<?php echo $locale; ?>">
-                            <?php $display = Locale::getDisplayLanguage($locale, $locale); ?>
-                            <?php echo $display . " (" . $locale . ")"; ?>
-                        </option>
-                    <?php endforeach; ?>
                 </select>
 
                 <details class="advanced">


### PR DESCRIPTION
## Description

Moved Locale field above Date format field in the demo site.

This order makes more sense since changing the Locale effects the default setting for date format so should be changed first to know what the default actually will look like. If the date format is changed first, the internationalized date format won't be seen by the user.

### Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (added a non-breaking change which fixes an issue)
- [ ] New feature (added a non-breaking change which adds functionality)
- [ ] Updated documentation (updated the readme, templates, or other repo files)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

<!--
If you have changed a feature of the stats cards, please describe the tests you made to verify your changes.
Changes strictly related to documentation can skip this section.
-->

- [ ] Tested locally with a valid username
- [ ] Tested locally with an invalid username
- [ ] Ran tests with `composer test`
- [ ] Added or updated test cases to test new features

## Checklist:

- [x] I have checked to make sure no other [pull requests](https://github.com/DenverCoder1/github-readme-streak-stats/pulls?q=is%3Apr+sort%3Aupdated-desc+) are open for this issue
- [x] The code is properly formatted and is consistent with the existing code style
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

## Screenshots

<!-- If you have updated the design or appearance, please include a screenshot of your changes. -->
