### PR TITLE
Added .devcontainer for GitHub Codespaces.

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,4 +3,4 @@ FROM mcr.microsoft.com/vscode/devcontainers/base:ubuntu-22.04
 ADD first-run-notice.txt /usr/local/etc/vscode-dev-containers/first-run-notice.txt
 
 RUN apt-get update -y && \
-    apt-get install -y php php-curl php-imagick php-xml composer
+    apt-get install -y php php-curl php-xml inkscape composer

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,6 @@
+FROM mcr.microsoft.com/vscode/devcontainers/base:ubuntu-22.04
+
+ADD first-run-notice.txt /usr/local/etc/vscode-dev-containers/first-run-notice.txt
+
+RUN apt-get update -y && \
+    apt-get install -y php php-curl php-imagick php-xml composer

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,6 @@
+{
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "onCreateCommand": "/workspaces/github-readme-streak-stats/.devcontainer/on-create.sh",
+  "postCreateCommand": "/workspaces/github-readme-streak-stats/.devcontainer/post-create.sh"}

--- a/.devcontainer/first-run-notice.txt
+++ b/.devcontainer/first-run-notice.txt
@@ -1,0 +1,3 @@
+👋 Welcome to Codespaces! You are using the pre-configured image.
+
+Tests can be executed with: composer test

--- a/.devcontainer/on-create.sh
+++ b/.devcontainer/on-create.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+
+cd /workspaces/github-readme-streak-stats
+composer install

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+
+cd /workspaces/github-readme-streak-stats
+if [ -n "$GITHUB_TOKEN" ]; then
+  echo "TOKEN=$GITHUB_TOKEN" > .env
+fi


### PR DESCRIPTION
## Description

This pull requests adds a devcontainer configuration that will be used when a codespace is started in this repository. This configuration installs the packages that are required to run the unit tests of this project. And it also uses the `$GITHUB_TOKEN` variable that is available in a codespaces to create the `.env` file that is used by the unit tests. I have also added a file called `first-run-notice.txt` that will be shown when the codespace is started. It might need some more improvements but I will leave that up to the maintainers of this project.

When trying to get `composer test` to work I also noticed that I needed different packages to make it work. I don't have enough php experience to know what to change in the `composer.json` file or `README.md` so I will leave that up to the maintainers of this projects.

### Type of change

- [x] New feature (added a non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Ran tests with `composer test`

## Checklist:

- [x] I have checked to make sure no other [pull requests](https://github.com/DenverCoder1/github-readme-streak-stats/pulls?q=is%3Apr+sort%3Aupdated-desc+) are open for this issue
- [x] The code is properly formatted and is consistent with the existing code style
