### PR TITLE
docs: Update links to demolab custom domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 2. Replace the value after `?user=` with your GitHub username
 
 ```md
-[![GitHub Streak](https://github-readme-streak-stats.herokuapp.com/?user=DenverCoder1)](https://git.io/streak-stats)
+[![GitHub Streak](https://streak-stats.demolab.com/?user=DenverCoder1)](https://git.io/streak-stats)
 ```
 
 > Note: See below for information about deploying the app on your own
@@ -31,16 +31,16 @@
 
 Here you can customize your Streak Stats card with a live preview.
 
-<http://github-readme-streak-stats.herokuapp.com/demo/>
+<http://streak-stats.demolab.com/demo/>
 
-[![Demo Site](https://user-images.githubusercontent.com/20955511/114579753-dbac8780-9c86-11eb-97dd-207039f67d20.gif "Demo Site")](http://github-readme-streak-stats.herokuapp.com/demo/)
+[![Demo Site](https://user-images.githubusercontent.com/20955511/114579753-dbac8780-9c86-11eb-97dd-207039f67d20.gif "Demo Site")](http://streak-stats.demolab.com/demo/)
 
 ## 🖌 Themes
 
 To enable a theme, append `&theme=` followed by the theme name to the end of the source url:
 
 ```md
-[![GitHub Streak](https://github-readme-streak-stats.herokuapp.com/?user=DenverCoder1&theme=dark)](https://git.io/streak-stats)
+[![GitHub Streak](https://streak-stats.demolab.com/?user=DenverCoder1&theme=dark)](https://git.io/streak-stats)
 ```
 
 |     Theme      |                            Preview                            |
@@ -97,7 +97,7 @@ When the contribution year is equal to the current year, the characters in brack
 ### Example
 
 ```md
-[![GitHub Streak](https://github-readme-streak-stats.herokuapp.com/?user=denvercoder1&currStreakNum=2FD3EB&fire=pink&sideLabels=F00&date_format=[Y.]n.j)](https://git.io/streak-stats)
+[![GitHub Streak](https://streak-stats.demolab.com/?user=denvercoder1&currStreakNum=2FD3EB&fire=pink&sideLabels=F00&date_format=[Y.]n.j)](https://git.io/streak-stats)
 ```
 
 ## ℹ️ How these stats are calculated
@@ -143,7 +143,7 @@ You can deploy the PHP files on any website server with PHP installed or as a He
 ![heroku config variables](https://user-images.githubusercontent.com/20955511/136292022-a8d9b3b5-d7d8-4a5e-a049-8d23b51ce9d7.png)
 
 6. Click **"Deploy App"** at the end of the form
-7. Once the app is deployed, you can use `<your-app-name>.herokuapp.com` in place of `github-readme-streak-stats.herokuapp.com`
+7. Once the app is deployed, you can use `<your-app-name>.herokuapp.com` in place of `streak-stats.demolab.com`
 
 </details>
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -2,19 +2,19 @@
 
 ## How do I include GitHub Readme Streak Stats in my Readme?
 
-Markdown files on GitHub support embedded images using Markdown or HTML. You can customize your Streak Stats image on the [demo site](https://github-readme-streak-stats.herokuapp.com/demo/) and use the image source in either of the following ways:
+Markdown files on GitHub support embedded images using Markdown or HTML. You can customize your Streak Stats image on the [demo site](https://streak-stats.demolab.com/demo/) and use the image source in either of the following ways:
 
 ### Markdown
 
 ```md
-[![GitHub Streak](https://github-readme-streak-stats.herokuapp.com?user=DenverCoder1)](https://git.io/streak-stats)
+[![GitHub Streak](https://streak-stats.demolab.com?user=DenverCoder1)](https://git.io/streak-stats)
 ```
 
 ### HTML
 
 <!-- prettier-ignore-start -->
 ```html
-<a href="https://git.io/streak-stats"><img src="https://github-readme-streak-stats.herokuapp.com?user=DenverCoder1"/></a>
+<a href="https://git.io/streak-stats"><img src="https://streak-stats.demolab.com?user=DenverCoder1"/></a>
 ```
 <!-- prettier-ignore-end -->
 
@@ -53,7 +53,7 @@ To center align images, you must use the HTML syntax and wrap it in an element w
 <!-- prettier-ignore-start -->
 ```html
 <p align="center">
-    <a href="https://git.io/streak-stats"><img src="https://github-readme-streak-stats.herokuapp.com?user=DenverCoder1"/></a>
+    <a href="https://git.io/streak-stats"><img src="https://streak-stats.demolab.com?user=DenverCoder1"/></a>
 </p>
 ```
 <!-- prettier-ignore-end -->
@@ -65,8 +65,8 @@ You can [specify theme context](https://github.blog/changelog/2022-05-19-specify
 <!-- prettier-ignore-start -->
 ```html
 <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://github-readme-streak-stats.herokuapp.com?user=DenverCoder1&theme=dark" />
-    <img src="https://github-readme-streak-stats.herokuapp.com?user=DenverCoder1&theme=default" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://streak-stats.demolab.com?user=DenverCoder1&theme=dark" />
+    <img src="https://streak-stats.demolab.com?user=DenverCoder1&theme=default" />
 </picture>
 ```
 <!-- prettier-ignore-end -->

--- a/docs/themes.md
+++ b/docs/themes.md
@@ -2,7 +2,7 @@
 
 To enable a theme, append `&theme=` followed by the theme name to the end of your url.
 
-You can also try out and customize these themes on the [Demo Site](https://github-readme-streak-stats.herokuapp.com/demo/).
+You can also try out and customize these themes on the [Demo Site](https://streak-stats.demolab.com/demo/).
 
 |             Theme             |                                                     Preview                                                      |
 | :---------------------------: | :--------------------------------------------------------------------------------------------------------------: |
@@ -98,6 +98,6 @@ You can also try out and customize these themes on the [Demo Site](https://githu
 
 ### Can't find the theme you like?
 
-You can now customize your stats card with the interactive [Demo Site](https://github-readme-streak-stats.herokuapp.com/demo/) or by customizing the [url parameters](/README.md#-options).
+You can now customize your stats card with the interactive [Demo Site](https://streak-stats.demolab.com/demo/) or by customizing the [url parameters](/README.md#-options).
 
 If you would like to share your theme with others, feel free to open an issue/pull request!


### PR DESCRIPTION
It is still hosted on Heroku, just added a new custom domain to make it easier to move the hosting in the future if necessary