### PR TITLE
feat: Wrap long lines and allow for two-line translation strings

### DIFF
--- a/src/card.php
+++ b/src/card.php
@@ -122,7 +122,7 @@ function getRequestedTheme(array $params): array
 function splitLines(string $text, int $maxChars, int $line1Offset): string
 {
     // if too many characters, insert \n before a " " or "-" if possible
-    if (strlen($text) > $maxChars) {
+    if (mb_strlen($text) > $maxChars) {
         // prefer splitting at " - " if possible
         if (strpos($text, " - ") !== false) {
             $text = str_replace(" - ", "\n- ", $text);
@@ -201,9 +201,9 @@ function generateCard(array $stats, array $params = null): string
     }
 
     // if the translations contain a newline, split the text into two tspan elements
-    $totalContributionsText = splitLines($localeTranslations["Total Contributions"], 24, -8);
-    $currentStreakText = splitLines($localeTranslations["Current Streak"], 22, -8);
-    $longestStreakText = splitLines($localeTranslations["Longest Streak"], 24, -8);
+    $totalContributionsText = splitLines($localeTranslations["Total Contributions"], 24, -10);
+    $currentStreakText = splitLines($localeTranslations["Current Streak"], 22, -10);
+    $longestStreakText = splitLines($localeTranslations["Longest Streak"], 24, -10);
 
     // if the ranges contain over 28 characters, split the text into two tspan elements
     $totalContributionsRange = splitLines($totalContributionsRange, 28, 0);

--- a/src/card.php
+++ b/src/card.php
@@ -201,9 +201,9 @@ function generateCard(array $stats, array $params = null): string
     }
 
     // if the translations contain a newline, split the text into two tspan elements
-    $totalContributionsText = splitLines($localeTranslations["Total Contributions"], 24, -10);
-    $currentStreakText = splitLines($localeTranslations["Current Streak"], 22, -10);
-    $longestStreakText = splitLines($localeTranslations["Longest Streak"], 24, -10);
+    $totalContributionsText = splitLines($localeTranslations["Total Contributions"], 24, -9);
+    $currentStreakText = splitLines($localeTranslations["Current Streak"], 22, -9);
+    $longestStreakText = splitLines($localeTranslations["Longest Streak"], 24, -9);
 
     // if the ranges contain over 28 characters, split the text into two tspan elements
     $totalContributionsRange = splitLines($totalContributionsRange, 28, 0);

--- a/src/card.php
+++ b/src/card.php
@@ -122,7 +122,7 @@ function getRequestedTheme(array $params): array
 function splitLines(string $text, int $maxChars, int $line1Offset): string
 {
     // if too many characters, insert \n before a " " or "-" if possible
-    if (mb_strlen($text) > $maxChars) {
+    if (mb_strlen($text) > $maxChars && strpos($text, "\n") === false) {
         // prefer splitting at " - " if possible
         if (strpos($text, " - ") !== false) {
             $text = str_replace(" - ", "\n- ", $text);

--- a/src/card.php
+++ b/src/card.php
@@ -111,6 +111,22 @@ function getRequestedTheme(array $params): array
 }
 
 /**
+ * Split lines of text using <tspan> elements if it contains a newline
+ *
+ * @param string $text Text to split
+ *
+ * @return string Original text if one line, or split text with <tspan> elements
+ */
+function splitLines(string $text): string
+{
+    return preg_replace(
+        "/^(.*)\n(.*)$/",
+        "<tspan x='81.5' dy='-8'>$1</tspan><tspan x='81.5' dy='16'>$2</tspan>",
+        $text
+    );
+}
+
+/**
  * Generate SVG output for a stats array
  *
  * @param array<string, mixed> $stats Streak stats
@@ -171,6 +187,11 @@ function generateCard(array $stats, array $params = null): string
         $longestStreakRange .= " - " . $longestStreakEnd;
     }
 
+    // if the translations contain a newline, split the text into two tspan elements
+    $totalContributionsText = splitLines($localeTranslations["Total Contributions"]);
+    $currentStreakText = splitLines($localeTranslations["Current Streak"]);
+    $longestStreakText = splitLines($localeTranslations["Longest Streak"]);
+
     return "<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink'
                 style='isolation:isolate' viewBox='0 0 495 195' width='495px' height='195px' direction='{$direction}'>
         <style>
@@ -204,7 +225,6 @@ function generateCard(array $stats, array $params = null): string
             <g style='isolation:isolate'>
                 <!-- Total Contributions Big Number -->
                 <g transform='translate(1,48)'>
-                    <rect width='163' height='50' stroke='none' fill='none'></rect>
                     <text x='81.5' y='32' stroke-width='0' text-anchor='middle' style='font-family:Segoe UI, Ubuntu, sans-serif;font-weight:700;font-size:28px;font-style:normal;fill:{$theme["sideNums"]};stroke:none; opacity: 0; animation: fadein 0.5s linear forwards 0.6s;'>
                         {$totalContributions}
                     </text>
@@ -212,15 +232,13 @@ function generateCard(array $stats, array $params = null): string
 
                 <!-- Total Contributions Label -->
                 <g transform='translate(1,84)'>
-                    <rect width='163' height='50' stroke='none' fill='none'></rect>
                     <text x='81.5' y='32' stroke-width='0' text-anchor='middle' style='font-family:Segoe UI, Ubuntu, sans-serif;font-weight:400;font-size:14px;font-style:normal;fill:{$theme["sideLabels"]};stroke:none; opacity: 0; animation: fadein 0.5s linear forwards 0.7s;'>
-                        {$localeTranslations["Total Contributions"]}
+                        {$totalContributionsText}
                     </text>
                 </g>
 
                 <!-- total contributions range -->
                 <g transform='translate(1,114)'>
-                    <rect width='163' height='50' stroke='none' fill='none'></rect>
                     <text x='81.5' y='32' stroke-width='0' text-anchor='middle' style='font-family:Segoe UI, Ubuntu, sans-serif;font-weight:400;font-size:12px;font-style:normal;fill:{$theme["dates"]};stroke:none; opacity: 0; animation: fadein 0.5s linear forwards 0.8s;'>
                         {$totalContributionsRange}
                     </text>
@@ -229,7 +247,6 @@ function generateCard(array $stats, array $params = null): string
             <g style='isolation:isolate'>
                 <!-- Current Streak Big Number -->
                 <g transform='translate(166,48)'>
-                    <rect width='163' height='50' stroke='none' fill='none'></rect>
                     <text x='81.5' y='32' stroke-width='0' text-anchor='middle' style='font-family:Segoe UI, Ubuntu, sans-serif;font-weight:700;font-size:28px;font-style:normal;fill:{$theme["currStreakNum"]};stroke:none;animation: currstreak 0.6s linear forwards;'>
                         {$currentStreak}
                     </text>
@@ -237,15 +254,13 @@ function generateCard(array $stats, array $params = null): string
 
                 <!-- Current Streak Label -->
                 <g transform='translate(166,108)'>
-                    <rect width='163' height='50' stroke='none' fill='none'></rect>
                     <text x='81.5' y='32' stroke-width='0' text-anchor='middle' style='font-family:Segoe UI, Ubuntu, sans-serif;font-weight:700;font-size:14px;font-style:normal;fill:{$theme["currStreakLabel"]};stroke:none;opacity: 0; animation: fadein 0.5s linear forwards 0.9s;'>
-                        {$localeTranslations["Current Streak"]}
+                        {$currentStreakText}
                     </text>
                 </g>
 
                 <!-- Current Streak Range -->
                 <g transform='translate(166,145)'>
-                    <rect width='163' height='26' stroke='none' fill='none'></rect>
                     <text x='81.5' y='21' stroke-width='0' text-anchor='middle' style='font-family:Segoe UI, Ubuntu, sans-serif;font-weight:400;font-size:12px;font-style:normal;fill:{$theme["dates"]};stroke:none;opacity: 0; animation: fadein 0.5s linear forwards 0.9s;'>
                         {$currentStreakRange}
                     </text>
@@ -265,7 +280,6 @@ function generateCard(array $stats, array $params = null): string
             <g style='isolation:isolate'>
                 <!-- Longest Streak Big Number -->
                 <g transform='translate(331,48)'>
-                    <rect width='163' height='50' stroke='none' fill='none'></rect>
                     <text x='81.5' y='32' stroke-width='0' text-anchor='middle' style='font-family:Segoe UI, Ubuntu, sans-serif;font-weight:700;font-size:28px;font-style:normal;fill:{$theme["sideNums"]};stroke:none; opacity: 0; animation: fadein 0.5s linear forwards 1.2s;'>
                         {$longestStreak}
                     </text>
@@ -273,15 +287,13 @@ function generateCard(array $stats, array $params = null): string
 
                 <!-- Longest Streak Label -->
                 <g transform='translate(331,84)'>
-                    <rect width='163' height='50' stroke='none' fill='none'></rect>
                     <text x='81.5' y='32' stroke-width='0' text-anchor='middle' style='font-family:Segoe UI, Ubuntu, sans-serif;font-weight:400;font-size:14px;font-style:normal;fill:{$theme["sideLabels"]};stroke:none;opacity: 0; animation: fadein 0.5s linear forwards 1.3s;'>
-                        {$localeTranslations["Longest Streak"]}
+                        {$longestStreakText}
                     </text>
                 </g>
 
                 <!-- Longest Streak Range -->
                 <g transform='translate(331,114)'>
-                    <rect width='163' height='50' stroke='none' fill='none'></rect>
                     <text x='81.5' y='32' stroke-width='0' text-anchor='middle' style='font-family:Segoe UI, Ubuntu, sans-serif;font-weight:400;font-size:12px;font-style:normal;fill:{$theme["dates"]};stroke:none;opacity: 0; animation: fadein 0.5s linear forwards 1.4s;'>
                         {$longestStreakRange}
                     </text>
@@ -328,7 +340,6 @@ function generateErrorCard(string $message, array $params = null): string
             <g style='isolation:isolate'>
                 <!-- Error Label -->
                 <g transform='translate(166,108)'>
-                    <rect width='163' height='50' stroke='none' fill='none'></rect>
                     <text x='81.5' y='50' dy='0.25em' stroke-width='0' text-anchor='middle' style='font-family:Segoe UI, Ubuntu, sans-serif;font-weight:400;font-size:14px;font-style:normal;fill:{$theme["sideLabels"]};stroke:none;'>
                         {$message}
                     </text>

--- a/tests/RenderTest.php
+++ b/tests/RenderTest.php
@@ -107,4 +107,33 @@ final class RenderTest extends TestCase
         $expected = file_get_contents("tests/expected/test_stats.json");
         $this->assertEquals($expected, $render);
     }
+
+    /**
+     * Test split lines function
+     */
+    public function testSplitLines(): void
+    {
+        // Check normal label, no split
+        $this->assertEquals("Total Contributions", splitLines("Total Contributions", 24, -9));
+        // Check label that is too long, split
+        $this->assertEquals(
+            "<tspan x='81.5' dy='-9'>Chuỗi đóng góp</tspan><tspan x='81.5' dy='16'>hiện tại</tspan>",
+            splitLines("Chuỗi đóng góp hiện tại", 22, -9)
+        );
+        // Check label with manually inserted line break, split
+        $this->assertEquals(
+            "<tspan x='81.5' dy='-9'>Chuỗi đóng</tspan><tspan x='81.5' dy='16'>góp hiện tại</tspan>",
+            splitLines("Chuỗi đóng\ngóp hiện tại", 22, -9)
+        );
+        // Check date range label, no split
+        $this->assertEquals(
+            "Mar 28, 2019 – Apr 12, 2019",
+            splitLines("Mar 28, 2019 – Apr 12, 2019", 28, 0)
+        );
+        // Check date range label that is too long, split
+        $this->assertEquals(
+            "<tspan x='81.5' dy='0'>19 de dez. de 2021</tspan><tspan x='81.5' dy='16'>- 14 de mar.</tspan>",
+            splitLines("19 de dez. de 2021 - 14 de mar.", 24, 0)
+        );
+    }
 }

--- a/tests/RenderTest.php
+++ b/tests/RenderTest.php
@@ -126,10 +126,7 @@ final class RenderTest extends TestCase
             splitLines("Chuỗi đóng\ngóp hiện tại", 22, -9)
         );
         // Check date range label, no split
-        $this->assertEquals(
-            "Mar 28, 2019 – Apr 12, 2019",
-            splitLines("Mar 28, 2019 – Apr 12, 2019", 28, 0)
-        );
+        $this->assertEquals("Mar 28, 2019 – Apr 12, 2019", splitLines("Mar 28, 2019 – Apr 12, 2019", 28, 0));
         // Check date range label that is too long, split
         $this->assertEquals(
             "<tspan x='81.5' dy='0'>19 de dez. de 2021</tspan><tspan x='81.5' dy='16'>- 14 de mar.</tspan>",

--- a/tests/expected/test_border_radius_card.svg
+++ b/tests/expected/test_border_radius_card.svg
@@ -31,7 +31,6 @@
             <g style='isolation:isolate'>
                 <!-- Total Contributions Big Number -->
                 <g transform='translate(1,48)'>
-                    <rect width='163' height='50' stroke='none' fill='none'></rect>
                     <text x='81.5' y='32' stroke-width='0' text-anchor='middle' style='font-family:Segoe UI, Ubuntu, sans-serif;font-weight:700;font-size:28px;font-style:normal;fill:#666666;stroke:none; opacity: 0; animation: fadein 0.5s linear forwards 0.6s;'>
                         2,048
                     </text>
@@ -39,7 +38,6 @@
 
                 <!-- Total Contributions Label -->
                 <g transform='translate(1,84)'>
-                    <rect width='163' height='50' stroke='none' fill='none'></rect>
                     <text x='81.5' y='32' stroke-width='0' text-anchor='middle' style='font-family:Segoe UI, Ubuntu, sans-serif;font-weight:400;font-size:14px;font-style:normal;fill:#888888;stroke:none; opacity: 0; animation: fadein 0.5s linear forwards 0.7s;'>
                         Total Contributions
                     </text>
@@ -47,7 +45,6 @@
 
                 <!-- total contributions range -->
                 <g transform='translate(1,114)'>
-                    <rect width='163' height='50' stroke='none' fill='none'></rect>
                     <text x='81.5' y='32' stroke-width='0' text-anchor='middle' style='font-family:Segoe UI, Ubuntu, sans-serif;font-weight:400;font-size:12px;font-style:normal;fill:#999999;stroke:none; opacity: 0; animation: fadein 0.5s linear forwards 0.8s;'>
                         Aug 10, 2016 - Present
                     </text>
@@ -56,7 +53,6 @@
             <g style='isolation:isolate'>
                 <!-- Current Streak Big Number -->
                 <g transform='translate(166,48)'>
-                    <rect width='163' height='50' stroke='none' fill='none'></rect>
                     <text x='81.5' y='32' stroke-width='0' text-anchor='middle' style='font-family:Segoe UI, Ubuntu, sans-serif;font-weight:700;font-size:28px;font-style:normal;fill:#555555;stroke:none;animation: currstreak 0.6s linear forwards;'>
                         16
                     </text>
@@ -64,7 +60,6 @@
 
                 <!-- Current Streak Label -->
                 <g transform='translate(166,108)'>
-                    <rect width='163' height='50' stroke='none' fill='none'></rect>
                     <text x='81.5' y='32' stroke-width='0' text-anchor='middle' style='font-family:Segoe UI, Ubuntu, sans-serif;font-weight:700;font-size:14px;font-style:normal;fill:#777777;stroke:none;opacity: 0; animation: fadein 0.5s linear forwards 0.9s;'>
                         Current Streak
                     </text>
@@ -72,7 +67,6 @@
 
                 <!-- Current Streak Range -->
                 <g transform='translate(166,145)'>
-                    <rect width='163' height='26' stroke='none' fill='none'></rect>
                     <text x='81.5' y='21' stroke-width='0' text-anchor='middle' style='font-family:Segoe UI, Ubuntu, sans-serif;font-weight:400;font-size:12px;font-style:normal;fill:#999999;stroke:none;opacity: 0; animation: fadein 0.5s linear forwards 0.9s;'>
                         Mar 28, 2019 - Apr 12, 2019
                     </text>
@@ -92,7 +86,6 @@
             <g style='isolation:isolate'>
                 <!-- Longest Streak Big Number -->
                 <g transform='translate(331,48)'>
-                    <rect width='163' height='50' stroke='none' fill='none'></rect>
                     <text x='81.5' y='32' stroke-width='0' text-anchor='middle' style='font-family:Segoe UI, Ubuntu, sans-serif;font-weight:700;font-size:28px;font-style:normal;fill:#666666;stroke:none; opacity: 0; animation: fadein 0.5s linear forwards 1.2s;'>
                         86
                     </text>
@@ -100,7 +93,6 @@
 
                 <!-- Longest Streak Label -->
                 <g transform='translate(331,84)'>
-                    <rect width='163' height='50' stroke='none' fill='none'></rect>
                     <text x='81.5' y='32' stroke-width='0' text-anchor='middle' style='font-family:Segoe UI, Ubuntu, sans-serif;font-weight:400;font-size:14px;font-style:normal;fill:#888888;stroke:none;opacity: 0; animation: fadein 0.5s linear forwards 1.3s;'>
                         Longest Streak
                     </text>
@@ -108,7 +100,6 @@
 
                 <!-- Longest Streak Range -->
                 <g transform='translate(331,114)'>
-                    <rect width='163' height='50' stroke='none' fill='none'></rect>
                     <text x='81.5' y='32' stroke-width='0' text-anchor='middle' style='font-family:Segoe UI, Ubuntu, sans-serif;font-weight:400;font-size:12px;font-style:normal;fill:#999999;stroke:none;opacity: 0; animation: fadein 0.5s linear forwards 1.4s;'>
                         Dec 19, 2016 - Mar 14, 2016
                     </text>

--- a/tests/expected/test_card.svg
+++ b/tests/expected/test_card.svg
@@ -31,7 +31,6 @@
             <g style='isolation:isolate'>
                 <!-- Total Contributions Big Number -->
                 <g transform='translate(1,48)'>
-                    <rect width='163' height='50' stroke='none' fill='none'></rect>
                     <text x='81.5' y='32' stroke-width='0' text-anchor='middle' style='font-family:Segoe UI, Ubuntu, sans-serif;font-weight:700;font-size:28px;font-style:normal;fill:#666666;stroke:none; opacity: 0; animation: fadein 0.5s linear forwards 0.6s;'>
                         2,048
                     </text>
@@ -39,7 +38,6 @@
 
                 <!-- Total Contributions Label -->
                 <g transform='translate(1,84)'>
-                    <rect width='163' height='50' stroke='none' fill='none'></rect>
                     <text x='81.5' y='32' stroke-width='0' text-anchor='middle' style='font-family:Segoe UI, Ubuntu, sans-serif;font-weight:400;font-size:14px;font-style:normal;fill:#888888;stroke:none; opacity: 0; animation: fadein 0.5s linear forwards 0.7s;'>
                         Total Contributions
                     </text>
@@ -47,7 +45,6 @@
 
                 <!-- total contributions range -->
                 <g transform='translate(1,114)'>
-                    <rect width='163' height='50' stroke='none' fill='none'></rect>
                     <text x='81.5' y='32' stroke-width='0' text-anchor='middle' style='font-family:Segoe UI, Ubuntu, sans-serif;font-weight:400;font-size:12px;font-style:normal;fill:#999999;stroke:none; opacity: 0; animation: fadein 0.5s linear forwards 0.8s;'>
                         Aug 10, 2016 - Present
                     </text>
@@ -56,7 +53,6 @@
             <g style='isolation:isolate'>
                 <!-- Current Streak Big Number -->
                 <g transform='translate(166,48)'>
-                    <rect width='163' height='50' stroke='none' fill='none'></rect>
                     <text x='81.5' y='32' stroke-width='0' text-anchor='middle' style='font-family:Segoe UI, Ubuntu, sans-serif;font-weight:700;font-size:28px;font-style:normal;fill:#555555;stroke:none;animation: currstreak 0.6s linear forwards;'>
                         16
                     </text>
@@ -64,7 +60,6 @@
 
                 <!-- Current Streak Label -->
                 <g transform='translate(166,108)'>
-                    <rect width='163' height='50' stroke='none' fill='none'></rect>
                     <text x='81.5' y='32' stroke-width='0' text-anchor='middle' style='font-family:Segoe UI, Ubuntu, sans-serif;font-weight:700;font-size:14px;font-style:normal;fill:#777777;stroke:none;opacity: 0; animation: fadein 0.5s linear forwards 0.9s;'>
                         Current Streak
                     </text>
@@ -72,7 +67,6 @@
 
                 <!-- Current Streak Range -->
                 <g transform='translate(166,145)'>
-                    <rect width='163' height='26' stroke='none' fill='none'></rect>
                     <text x='81.5' y='21' stroke-width='0' text-anchor='middle' style='font-family:Segoe UI, Ubuntu, sans-serif;font-weight:400;font-size:12px;font-style:normal;fill:#999999;stroke:none;opacity: 0; animation: fadein 0.5s linear forwards 0.9s;'>
                         Mar 28, 2019 - Apr 12, 2019
                     </text>
@@ -92,7 +86,6 @@
             <g style='isolation:isolate'>
                 <!-- Longest Streak Big Number -->
                 <g transform='translate(331,48)'>
-                    <rect width='163' height='50' stroke='none' fill='none'></rect>
                     <text x='81.5' y='32' stroke-width='0' text-anchor='middle' style='font-family:Segoe UI, Ubuntu, sans-serif;font-weight:700;font-size:28px;font-style:normal;fill:#666666;stroke:none; opacity: 0; animation: fadein 0.5s linear forwards 1.2s;'>
                         86
                     </text>
@@ -100,7 +93,6 @@
 
                 <!-- Longest Streak Label -->
                 <g transform='translate(331,84)'>
-                    <rect width='163' height='50' stroke='none' fill='none'></rect>
                     <text x='81.5' y='32' stroke-width='0' text-anchor='middle' style='font-family:Segoe UI, Ubuntu, sans-serif;font-weight:400;font-size:14px;font-style:normal;fill:#888888;stroke:none;opacity: 0; animation: fadein 0.5s linear forwards 1.3s;'>
                         Longest Streak
                     </text>
@@ -108,7 +100,6 @@
 
                 <!-- Longest Streak Range -->
                 <g transform='translate(331,114)'>
-                    <rect width='163' height='50' stroke='none' fill='none'></rect>
                     <text x='81.5' y='32' stroke-width='0' text-anchor='middle' style='font-family:Segoe UI, Ubuntu, sans-serif;font-weight:400;font-size:12px;font-style:normal;fill:#999999;stroke:none;opacity: 0; animation: fadein 0.5s linear forwards 1.4s;'>
                         Dec 19, 2016 - Mar 14, 2016
                     </text>

--- a/tests/expected/test_date_card.svg
+++ b/tests/expected/test_date_card.svg
@@ -31,7 +31,6 @@
             <g style='isolation:isolate'>
                 <!-- Total Contributions Big Number -->
                 <g transform='translate(1,48)'>
-                    <rect width='163' height='50' stroke='none' fill='none'></rect>
                     <text x='81.5' y='32' stroke-width='0' text-anchor='middle' style='font-family:Segoe UI, Ubuntu, sans-serif;font-weight:700;font-size:28px;font-style:normal;fill:#666666;stroke:none; opacity: 0; animation: fadein 0.5s linear forwards 0.6s;'>
                         2,048
                     </text>
@@ -39,7 +38,6 @@
 
                 <!-- Total Contributions Label -->
                 <g transform='translate(1,84)'>
-                    <rect width='163' height='50' stroke='none' fill='none'></rect>
                     <text x='81.5' y='32' stroke-width='0' text-anchor='middle' style='font-family:Segoe UI, Ubuntu, sans-serif;font-weight:400;font-size:14px;font-style:normal;fill:#888888;stroke:none; opacity: 0; animation: fadein 0.5s linear forwards 0.7s;'>
                         Total Contributions
                     </text>
@@ -47,7 +45,6 @@
 
                 <!-- total contributions range -->
                 <g transform='translate(1,114)'>
-                    <rect width='163' height='50' stroke='none' fill='none'></rect>
                     <text x='81.5' y='32' stroke-width='0' text-anchor='middle' style='font-family:Segoe UI, Ubuntu, sans-serif;font-weight:400;font-size:12px;font-style:normal;fill:#999999;stroke:none; opacity: 0; animation: fadein 0.5s linear forwards 0.8s;'>
                         2016-08-10 - Present
                     </text>
@@ -56,7 +53,6 @@
             <g style='isolation:isolate'>
                 <!-- Current Streak Big Number -->
                 <g transform='translate(166,48)'>
-                    <rect width='163' height='50' stroke='none' fill='none'></rect>
                     <text x='81.5' y='32' stroke-width='0' text-anchor='middle' style='font-family:Segoe UI, Ubuntu, sans-serif;font-weight:700;font-size:28px;font-style:normal;fill:#555555;stroke:none;animation: currstreak 0.6s linear forwards;'>
                         16
                     </text>
@@ -64,7 +60,6 @@
 
                 <!-- Current Streak Label -->
                 <g transform='translate(166,108)'>
-                    <rect width='163' height='50' stroke='none' fill='none'></rect>
                     <text x='81.5' y='32' stroke-width='0' text-anchor='middle' style='font-family:Segoe UI, Ubuntu, sans-serif;font-weight:700;font-size:14px;font-style:normal;fill:#777777;stroke:none;opacity: 0; animation: fadein 0.5s linear forwards 0.9s;'>
                         Current Streak
                     </text>
@@ -72,7 +67,6 @@
 
                 <!-- Current Streak Range -->
                 <g transform='translate(166,145)'>
-                    <rect width='163' height='26' stroke='none' fill='none'></rect>
                     <text x='81.5' y='21' stroke-width='0' text-anchor='middle' style='font-family:Segoe UI, Ubuntu, sans-serif;font-weight:400;font-size:12px;font-style:normal;fill:#999999;stroke:none;opacity: 0; animation: fadein 0.5s linear forwards 0.9s;'>
                         2019-03-28 - 04-12
                     </text>
@@ -92,7 +86,6 @@
             <g style='isolation:isolate'>
                 <!-- Longest Streak Big Number -->
                 <g transform='translate(331,48)'>
-                    <rect width='163' height='50' stroke='none' fill='none'></rect>
                     <text x='81.5' y='32' stroke-width='0' text-anchor='middle' style='font-family:Segoe UI, Ubuntu, sans-serif;font-weight:700;font-size:28px;font-style:normal;fill:#666666;stroke:none; opacity: 0; animation: fadein 0.5s linear forwards 1.2s;'>
                         86
                     </text>
@@ -100,7 +93,6 @@
 
                 <!-- Longest Streak Label -->
                 <g transform='translate(331,84)'>
-                    <rect width='163' height='50' stroke='none' fill='none'></rect>
                     <text x='81.5' y='32' stroke-width='0' text-anchor='middle' style='font-family:Segoe UI, Ubuntu, sans-serif;font-weight:400;font-size:14px;font-style:normal;fill:#888888;stroke:none;opacity: 0; animation: fadein 0.5s linear forwards 1.3s;'>
                         Longest Streak
                     </text>
@@ -108,7 +100,6 @@
 
                 <!-- Longest Streak Range -->
                 <g transform='translate(331,114)'>
-                    <rect width='163' height='50' stroke='none' fill='none'></rect>
                     <text x='81.5' y='32' stroke-width='0' text-anchor='middle' style='font-family:Segoe UI, Ubuntu, sans-serif;font-weight:400;font-size:12px;font-style:normal;fill:#999999;stroke:none;opacity: 0; animation: fadein 0.5s linear forwards 1.4s;'>
                         2016-12-19 - 2016-03-14
                     </text>

--- a/tests/expected/test_error_card.svg
+++ b/tests/expected/test_error_card.svg
@@ -16,7 +16,6 @@
             <g style='isolation:isolate'>
                 <!-- Error Label -->
                 <g transform='translate(166,108)'>
-                    <rect width='163' height='50' stroke='none' fill='none'></rect>
                     <text x='81.5' y='50' dy='0.25em' stroke-width='0' text-anchor='middle' style='font-family:Segoe UI, Ubuntu, sans-serif;font-weight:400;font-size:14px;font-style:normal;fill:#888888;stroke:none;'>
                         An unknown error occurred
                     </text>

--- a/tests/expected/test_locale_ja_card.svg
+++ b/tests/expected/test_locale_ja_card.svg
@@ -31,7 +31,6 @@
             <g style='isolation:isolate'>
                 <!-- Total Contributions Big Number -->
                 <g transform='translate(1,48)'>
-                    <rect width='163' height='50' stroke='none' fill='none'></rect>
                     <text x='81.5' y='32' stroke-width='0' text-anchor='middle' style='font-family:Segoe UI, Ubuntu, sans-serif;font-weight:700;font-size:28px;font-style:normal;fill:#666666;stroke:none; opacity: 0; animation: fadein 0.5s linear forwards 0.6s;'>
                         2,048
                     </text>
@@ -39,7 +38,6 @@
 
                 <!-- Total Contributions Label -->
                 <g transform='translate(1,84)'>
-                    <rect width='163' height='50' stroke='none' fill='none'></rect>
                     <text x='81.5' y='32' stroke-width='0' text-anchor='middle' style='font-family:Segoe UI, Ubuntu, sans-serif;font-weight:400;font-size:14px;font-style:normal;fill:#888888;stroke:none; opacity: 0; animation: fadein 0.5s linear forwards 0.7s;'>
                         総ｺﾝﾄﾘﾋﾞｭｰｼｮﾝ数
                     </text>
@@ -47,7 +45,6 @@
 
                 <!-- total contributions range -->
                 <g transform='translate(1,114)'>
-                    <rect width='163' height='50' stroke='none' fill='none'></rect>
                     <text x='81.5' y='32' stroke-width='0' text-anchor='middle' style='font-family:Segoe UI, Ubuntu, sans-serif;font-weight:400;font-size:12px;font-style:normal;fill:#999999;stroke:none; opacity: 0; animation: fadein 0.5s linear forwards 0.8s;'>
                         2016.8.10 - 今
                     </text>
@@ -56,7 +53,6 @@
             <g style='isolation:isolate'>
                 <!-- Current Streak Big Number -->
                 <g transform='translate(166,48)'>
-                    <rect width='163' height='50' stroke='none' fill='none'></rect>
                     <text x='81.5' y='32' stroke-width='0' text-anchor='middle' style='font-family:Segoe UI, Ubuntu, sans-serif;font-weight:700;font-size:28px;font-style:normal;fill:#555555;stroke:none;animation: currstreak 0.6s linear forwards;'>
                         16
                     </text>
@@ -64,7 +60,6 @@
 
                 <!-- Current Streak Label -->
                 <g transform='translate(166,108)'>
-                    <rect width='163' height='50' stroke='none' fill='none'></rect>
                     <text x='81.5' y='32' stroke-width='0' text-anchor='middle' style='font-family:Segoe UI, Ubuntu, sans-serif;font-weight:700;font-size:14px;font-style:normal;fill:#777777;stroke:none;opacity: 0; animation: fadein 0.5s linear forwards 0.9s;'>
                         現在のストリーク
                     </text>
@@ -72,7 +67,6 @@
 
                 <!-- Current Streak Range -->
                 <g transform='translate(166,145)'>
-                    <rect width='163' height='26' stroke='none' fill='none'></rect>
                     <text x='81.5' y='21' stroke-width='0' text-anchor='middle' style='font-family:Segoe UI, Ubuntu, sans-serif;font-weight:400;font-size:12px;font-style:normal;fill:#999999;stroke:none;opacity: 0; animation: fadein 0.5s linear forwards 0.9s;'>
                         2019.3.28 - 2019.4.12
                     </text>
@@ -92,7 +86,6 @@
             <g style='isolation:isolate'>
                 <!-- Longest Streak Big Number -->
                 <g transform='translate(331,48)'>
-                    <rect width='163' height='50' stroke='none' fill='none'></rect>
                     <text x='81.5' y='32' stroke-width='0' text-anchor='middle' style='font-family:Segoe UI, Ubuntu, sans-serif;font-weight:700;font-size:28px;font-style:normal;fill:#666666;stroke:none; opacity: 0; animation: fadein 0.5s linear forwards 1.2s;'>
                         86
                     </text>
@@ -100,7 +93,6 @@
 
                 <!-- Longest Streak Label -->
                 <g transform='translate(331,84)'>
-                    <rect width='163' height='50' stroke='none' fill='none'></rect>
                     <text x='81.5' y='32' stroke-width='0' text-anchor='middle' style='font-family:Segoe UI, Ubuntu, sans-serif;font-weight:400;font-size:14px;font-style:normal;fill:#888888;stroke:none;opacity: 0; animation: fadein 0.5s linear forwards 1.3s;'>
                         最長のストリーク
                     </text>
@@ -108,7 +100,6 @@
 
                 <!-- Longest Streak Range -->
                 <g transform='translate(331,114)'>
-                    <rect width='163' height='50' stroke='none' fill='none'></rect>
                     <text x='81.5' y='32' stroke-width='0' text-anchor='middle' style='font-family:Segoe UI, Ubuntu, sans-serif;font-weight:400;font-size:12px;font-style:normal;fill:#999999;stroke:none;opacity: 0; animation: fadein 0.5s linear forwards 1.4s;'>
                         2016.12.19 - 2016.3.14
                     </text>


### PR DESCRIPTION
## Description

Allows for 2-line translations and splits range text at " - " if the line exceeds 28 characters.

Translated labels will automatically split at 22 (bold) / 24 characters.

Newlines may be inserted manually in translations.php to override the max chars effect, eg. `"Total\nContributions"`)

Before
![image](https://user-images.githubusercontent.com/20955511/196016723-01a15c61-6c05-4d73-82a8-9dc51bb4ebe7.png)

After
![image](https://user-images.githubusercontent.com/20955511/196017075-9a4a9512-ae0e-4022-871a-897ac9e3e805.png)


Before
![image](https://user-images.githubusercontent.com/20955511/196017094-4f8f2255-1cf3-4c2d-a134-4b6290c19a73.png)

After
![image](https://user-images.githubusercontent.com/20955511/196017084-eb52ba4e-6f14-4e82-87c9-708370ed5d7f.png)


### Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (added a non-breaking change which fixes an issue)
- [x] New feature (added a non-breaking change which adds functionality)
- [ ] Updated documentation (updated the readme, templates, or other repo files)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

<!--
If you have changed a feature of the stats cards, please describe the tests you made to verify your changes.
Changes strictly related to documentation can skip this section.
-->

- [x] Tested locally with a valid username
- [x] Tested locally with an invalid username
- [x] Ran tests with `composer test`
- [x] Added or updated test cases to test new features

## Checklist:

- [x] I have checked to make sure no other [pull requests](https://github.com/DenverCoder1/github-readme-streak-stats/pulls?q=is%3Apr+sort%3Aupdated-desc+) are open for this issue
- [x] The code is properly formatted and is consistent with the existing code style
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
