### PR TITLE
fix: replace wordwrap to support utf8 words

### DIFF
--- a/Aptfile
+++ b/Aptfile
@@ -1,1 +1,2 @@
 inkscape
+php-mbstring

--- a/Aptfile
+++ b/Aptfile
@@ -1,2 +1,1 @@
 inkscape
-php-mbstring

--- a/src/card.php
+++ b/src/card.php
@@ -126,19 +126,14 @@ function getRequestedTheme(array $params): array
  */
 function utf8WordWrap($string, $width = 75, $break = "\n", $cut_long_words = false)
 {
+    // match anything 1 to $width chars long followed by whitespace or EOS
+    $string = preg_replace("/(.{1,$width})(?:\s|$)/uS", "$1$break", $string);
+    // split words that are too long after being broken up
     if ($cut_long_words) {
-        // match anything 1 to $width chars long followed by whitespace or EOS
-        $string = preg_replace("/(.{1,$width})(?:\s|$)/uS", "$1$break", $string);
-        // split words that are too long after being broken up
         $string = preg_replace("/(\S{" . $width . "})(?=\S)/u", "$1$break", $string);
-        // trim any trailing line breaks
-        return rtrim($string, $break);
-    } else {
-        // match anything 1 to $width chars long, but don't split words
-        $string = preg_replace("/(.{1,$width})(?:\s|$)/uS", "$1$break", $string);
-        // trim any trailing line breaks
-        return rtrim($string, $break);
     }
+    // trim any trailing line breaks
+    return rtrim($string, $break);
 }
 
 /**

--- a/src/card.php
+++ b/src/card.php
@@ -111,6 +111,33 @@ function getRequestedTheme(array $params): array
 }
 
 /**
+ * Wraps a string to a given number of characters
+ *
+ * Similar to `wordwrap()`, but uses regex and does not break with certain non-ascii characters
+ *
+ * @param string $string The input string
+ * @param int $width The number of characters at which the string will be wrapped
+ * @param string $break The line is broken using the optional `break` parameter
+ * @param bool $cut_long_words If the `cut_long_words` parameter is set to true, the string is
+ *              the string is always wrapped at or before the specified width. So if you have
+ *              a word that is larger than the given width, it is broken apart.
+ *              When false the function does not split the word even if the width is smaller
+ *              than the word width.
+ */
+function utf8WordWrap($string, $width = 75, $break = "\n", $cut_long_words = false)
+{
+    if ($cut_long_words) {
+        // match anything 1 to $width chars long followed by whitespace or EOS
+        $string = preg_replace("/(.{1,$width})(?:\s|$)/uS", "$1$break", $string);
+        // split words that are too long after being broken up
+        return preg_replace("/(\S{" . $width . "})(?=\S)/u", "$1$break", $string);
+    } else {
+        // match anything 1 to $width chars long, but don't split words
+        return preg_replace("/(.{1,$width})(?:\s|$)/uS", "$1$break", $string);
+    }
+}
+
+/**
  * Split lines of text using <tspan> elements if it contains a newline or exceeds a maximum number of characters
  *
  * @param string $text Text to split
@@ -127,13 +154,14 @@ function splitLines(string $text, int $maxChars, int $line1Offset): string
         if (strpos($text, " - ") !== false) {
             $text = str_replace(" - ", "\n- ", $text);
         }
-        // otherwise, use word wrap to split at " "
+        // otherwise, use word wrap to split at spaces
         else {
-            $text = wordwrap($text, $maxChars, "\n", true);
+            $text = utf8WordWrap($text, $maxChars, "\n", true);
         }
     }
+    $text = htmlspecialchars($text);
     return preg_replace(
-        "/^(.*)\n(.*)$/",
+        "/^(.*)\n(.*)/",
         "<tspan x='81.5' dy='{$line1Offset}'>$1</tspan><tspan x='81.5' dy='16'>$2</tspan>",
         $text
     );

--- a/src/card.php
+++ b/src/card.php
@@ -123,6 +123,7 @@ function getRequestedTheme(array $params): array
  *              a word that is larger than the given width, it is broken apart.
  *              When false the function does not split the word even if the width is smaller
  *              than the word width.
+ * @return string The given string wrapped at the specified length
  */
 function utf8WordWrap($string, $width = 75, $break = "\n", $cut_long_words = false)
 {
@@ -137,6 +138,19 @@ function utf8WordWrap($string, $width = 75, $break = "\n", $cut_long_words = fal
 }
 
 /**
+ * Get the length of a string with utf8 characters
+ *
+ * Similar to `strlen()`, but uses regex and does not break with certain non-ascii characters
+ *
+ * @param string $string The input string
+ * @return int The length of the string
+ */
+function utf8Strlen($string)
+{
+    return preg_match_all("/./us", $string, $matches);
+}
+
+/**
  * Split lines of text using <tspan> elements if it contains a newline or exceeds a maximum number of characters
  *
  * @param string $text Text to split
@@ -148,7 +162,7 @@ function utf8WordWrap($string, $width = 75, $break = "\n", $cut_long_words = fal
 function splitLines(string $text, int $maxChars, int $line1Offset): string
 {
     // if too many characters, insert \n before a " " or "-" if possible
-    if (mb_strlen($text) > $maxChars && strpos($text, "\n") === false) {
+    if (utf8Strlen($text) > $maxChars && strpos($text, "\n") === false) {
         // prefer splitting at " - " if possible
         if (strpos($text, " - ") !== false) {
             $text = str_replace(" - ", "\n- ", $text);

--- a/src/card.php
+++ b/src/card.php
@@ -130,10 +130,14 @@ function utf8WordWrap($string, $width = 75, $break = "\n", $cut_long_words = fal
         // match anything 1 to $width chars long followed by whitespace or EOS
         $string = preg_replace("/(.{1,$width})(?:\s|$)/uS", "$1$break", $string);
         // split words that are too long after being broken up
-        return preg_replace("/(\S{" . $width . "})(?=\S)/u", "$1$break", $string);
+        $string = preg_replace("/(\S{" . $width . "})(?=\S)/u", "$1$break", $string);
+        // trim any trailing line breaks
+        return rtrim($string, $break);
     } else {
         // match anything 1 to $width chars long, but don't split words
-        return preg_replace("/(.{1,$width})(?:\s|$)/uS", "$1$break", $string);
+        $string = preg_replace("/(.{1,$width})(?:\s|$)/uS", "$1$break", $string);
+        // trim any trailing line breaks
+        return rtrim($string, $break);
     }
 }
 

--- a/src/translations.php
+++ b/src/translations.php
@@ -126,7 +126,7 @@ return [
     ],
     "vi" => [
         "Total Contributions" => "Tổng số đóng góp",
-        "Current Streak" => "Chuỗi đóng góp hiện tại",
+        "Current Streak" => "Chuỗi đóng góp\nhiện tại",
         "Longest Streak" => "Chuỗi đóng góp lớn nhất",
         "Present" => "Hiện tại",
     ],

--- a/tests/RenderTest.php
+++ b/tests/RenderTest.php
@@ -117,13 +117,13 @@ final class RenderTest extends TestCase
         $this->assertEquals("Total Contributions", splitLines("Total Contributions", 24, -9));
         // Check label that is too long, split
         $this->assertEquals(
-            "<tspan x='81.5' dy='-9'>Chuỗi đóng góp</tspan><tspan x='81.5' dy='16'>hiện tại</tspan>",
+            "<tspan x='81.5' dy='-9'>Chuỗi đóng góp hiện</tspan><tspan x='81.5' dy='16'>tại</tspan>",
             splitLines("Chuỗi đóng góp hiện tại", 22, -9)
         );
         // Check label with manually inserted line break, split
         $this->assertEquals(
-            "<tspan x='81.5' dy='-9'>Chuỗi đóng</tspan><tspan x='81.5' dy='16'>góp hiện tại</tspan>",
-            splitLines("Chuỗi đóng\ngóp hiện tại", 22, -9)
+            "<tspan x='81.5' dy='-9'>Chuỗi đóng góp</tspan><tspan x='81.5' dy='16'>hiện tại</tspan>",
+            splitLines("Chuỗi đóng góp\nhiện tại", 22, -9)
         );
         // Check date range label, no split
         $this->assertEquals("Mar 28, 2019 – Apr 12, 2019", splitLines("Mar 28, 2019 – Apr 12, 2019", 28, 0));


### PR DESCRIPTION
## Description

Previously the wordwrap would cause display issues with text such as "மிக சமீபத்திய தொடர்ச்சியான பங்களிப்புகள்"

This implementation works better with other languages

### Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (added a non-breaking change which fixes an issue)
- [ ] New feature (added a non-breaking change which adds functionality)
- [ ] Updated documentation (updated the readme, templates, or other repo files)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

<!--
If you have changed a feature of the stats cards, please describe the tests you made to verify your changes.
Changes strictly related to documentation can skip this section.
-->

- [ ] Tested locally with a valid username
- [ ] Tested locally with an invalid username
- [ ] Ran tests with `composer test`
- [ ] Added or updated test cases to test new features

## Checklist:

- [x] I have checked to make sure no other [pull requests](https://github.com/DenverCoder1/github-readme-streak-stats/pulls?q=is%3Apr+sort%3Aupdated-desc+) are open for this issue
- [x] The code is properly formatted and is consistent with the existing code style
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Screenshots

<!-- If you have updated the design or appearance, please include a screenshot of your changes. -->
