### PR TITLE
feat: Added "halloween" streak stats theme

### DIFF
--- a/docs/themes.md
+++ b/docs/themes.md
@@ -98,6 +98,7 @@ You can also try out and customize these themes on the [Demo Site](https://strea
 |          `material`           | ![image](https://user-images.githubusercontent.com/20955511/193617994-dfab039d-b111-4a95-a00d-39517d9e40ab.png)  |
 |        `modern-lilac`         | ![image](https://user-images.githubusercontent.com/20955511/197569406-6ff144c3-1d6e-4500-9f0b-3112a6c62584.png)  |
 |        `modern-lilac2`        | ![image](https://user-images.githubusercontent.com/20955511/197575977-029fc730-9c7e-4556-be7c-a727a1715fa7.png)  |
+|          `halloween`          | ![image](https://user-images.githubusercontent.com/20955511/198897937-a3c918ea-0f35-43a0-9faf-80ad8f254cdf.png)  |
 
 ### Can't find the theme you like?
 

--- a/src/themes.php
+++ b/src/themes.php
@@ -1106,4 +1106,16 @@ return [
         "sideLabels" => "#c770f0",
         "dates" => "#FFFFFF",
     ],
+    "halloween" => [
+        "background" => "#1C1A2B",
+        "border" => "#FFC400",
+        "stroke" => "#FFC400",
+        "ring" => "#FDEF49",
+        "fire" => "#FDEF49",
+        "currStreakNum" => "#FFC400",
+        "sideNums" => "#FFC400",
+        "currStreakLabel" => "#FB9600",
+        "sideLabels" => "#FB9600",
+        "dates" => "#FFC400",
+    ],
 ];


### PR DESCRIPTION
## Description

Added "halloween" theme.

The inspiration comes from the GitHub Halloween contribution graphs that have appeared on October 31 each year.

![image](https://user-images.githubusercontent.com/20955511/198898029-7439f863-fd4d-4e01-8076-c39cfa7b5a0a.png)

This is an opt-in theme and can be used by setting the `theme` parameter to `halloween`.

### Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (added a non-breaking change which adds functionality)

## Checklist:

- [x] I have checked to make sure no other [pull requests](https://github.com/DenverCoder1/github-readme-streak-stats/pulls?q=is%3Apr+sort%3Aupdated-desc+) are open for this issue
- [x] The code is properly formatted and is consistent with the existing code style
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Screenshots

![image](https://user-images.githubusercontent.com/20955511/198897937-a3c918ea-0f35-43a0-9faf-80ad8f254cdf.png)
