### PR TITLE
refactor: Use font SVG attributes instead of CSS

### DIFF
--- a/src/card.php
+++ b/src/card.php
@@ -284,21 +284,21 @@ function generateCard(array $stats, array $params = null): string
             <g style='isolation: isolate'>
                 <!-- Total Contributions Big Number -->
                 <g transform='translate(1,48)'>
-                    <text x='81.5' y='32' stroke-width='0' text-anchor='middle' fill='{$theme["sideNums"]}' stroke='none' style='font-family: \"Segoe UI\", Ubuntu, sans-serif; font-weight: 700; font-size: 28px; font-style: normal; opacity: 0; animation: fadein 0.5s linear forwards 0.6s'>
+                    <text x='81.5' y='32' stroke-width='0' text-anchor='middle' fill='{$theme["sideNums"]}' stroke='none' font-family='\"Segoe UI\", Ubuntu, sans-serif' font-weight='700' font-size='28px' font-style='normal' style='opacity: 0; animation: fadein 0.5s linear forwards 0.6s'>
                         {$totalContributions}
                     </text>
                 </g>
 
                 <!-- Total Contributions Label -->
                 <g transform='translate(1,84)'>
-                    <text x='81.5' y='32' stroke-width='0' text-anchor='middle' fill='{$theme["sideLabels"]}' stroke='none' style='font-family: \"Segoe UI\", Ubuntu, sans-serif; font-weight: 400; font-size: 14px; font-style: normal; opacity: 0; animation: fadein 0.5s linear forwards 0.7s'>
+                    <text x='81.5' y='32' stroke-width='0' text-anchor='middle' fill='{$theme["sideLabels"]}' stroke='none' font-family='\"Segoe UI\", Ubuntu, sans-serif' font-weight='400' font-size='14px' font-style='normal' style='opacity: 0; animation: fadein 0.5s linear forwards 0.7s'>
                         {$totalContributionsText}
                     </text>
                 </g>
 
                 <!-- total contributions range -->
                 <g transform='translate(1,114)'>
-                    <text x='81.5' y='32' stroke-width='0' text-anchor='middle' fill='{$theme["dates"]}' stroke='none' style='font-family: \"Segoe UI\", Ubuntu, sans-serif; font-weight: 400; font-size: 12px; font-style: normal; opacity: 0; animation: fadein 0.5s linear forwards 0.8s'>
+                    <text x='81.5' y='32' stroke-width='0' text-anchor='middle' fill='{$theme["dates"]}' stroke='none' font-family='\"Segoe UI\", Ubuntu, sans-serif' font-weight='400' font-size='12px' font-style='normal' style='opacity: 0; animation: fadein 0.5s linear forwards 0.8s'>
                         {$totalContributionsRange}
                     </text>
                 </g>
@@ -306,21 +306,21 @@ function generateCard(array $stats, array $params = null): string
             <g style='isolation: isolate'>
                 <!-- Current Streak Big Number -->
                 <g transform='translate(166,48)'>
-                    <text x='81.5' y='32' stroke-width='0' text-anchor='middle' fill='{$theme["currStreakNum"]}' stroke='none' style='font-family: \"Segoe UI\", Ubuntu, sans-serif; font-weight: 700; font-size: 28px; font-style: normal; animation: currstreak 0.6s linear forwards'>
+                    <text x='81.5' y='32' stroke-width='0' text-anchor='middle' fill='{$theme["currStreakNum"]}' stroke='none' font-family='\"Segoe UI\", Ubuntu, sans-serif' font-weight='700' font-size='28px' font-style='normal' style='animation: currstreak 0.6s linear forwards'>
                         {$currentStreak}
                     </text>
                 </g>
 
                 <!-- Current Streak Label -->
                 <g transform='translate(166,108)'>
-                    <text x='81.5' y='32' stroke-width='0' text-anchor='middle' fill='{$theme["currStreakLabel"]}' stroke='none' style='font-family: \"Segoe UI\", Ubuntu, sans-serif; font-weight: 700; font-size: 14px; font-style: normal; opacity: 0; animation: fadein 0.5s linear forwards 0.9s'>
+                    <text x='81.5' y='32' stroke-width='0' text-anchor='middle' fill='{$theme["currStreakLabel"]}' stroke='none' font-family='\"Segoe UI\", Ubuntu, sans-serif' font-weight='700' font-size='14px' font-style='normal' style='opacity: 0; animation: fadein 0.5s linear forwards 0.9s'>
                         {$currentStreakText}
                     </text>
                 </g>
 
                 <!-- Current Streak Range -->
                 <g transform='translate(166,145)'>
-                    <text x='81.5' y='21' stroke-width='0' text-anchor='middle' fill='{$theme["dates"]}' stroke='none' style='font-family: \"Segoe UI\", Ubuntu, sans-serif; font-weight: 400; font-size: 12px; font-style: normal; opacity: 0; animation: fadein 0.5s linear forwards 0.9s'>
+                    <text x='81.5' y='21' stroke-width='0' text-anchor='middle' fill='{$theme["dates"]}' stroke='none' font-family='\"Segoe UI\", Ubuntu, sans-serif' font-weight='400' font-size='12px' font-style='normal' style='opacity: 0; animation: fadein 0.5s linear forwards 0.9s'>
                         {$currentStreakRange}
                     </text>
                 </g>
@@ -339,21 +339,21 @@ function generateCard(array $stats, array $params = null): string
             <g style='isolation: isolate'>
                 <!-- Longest Streak Big Number -->
                 <g transform='translate(331,48)'>
-                    <text x='81.5' y='32' stroke-width='0' text-anchor='middle' fill='{$theme["sideNums"]}' stroke='none' style='font-family: \"Segoe UI\", Ubuntu, sans-serif; font-weight: 700; font-size: 28px; font-style: normal; opacity: 0; animation: fadein 0.5s linear forwards 1.2s'>
+                    <text x='81.5' y='32' stroke-width='0' text-anchor='middle' fill='{$theme["sideNums"]}' stroke='none' font-family='\"Segoe UI\", Ubuntu, sans-serif' font-weight='700' font-size='28px' font-style='normal' style='opacity: 0; animation: fadein 0.5s linear forwards 1.2s'>
                         {$longestStreak}
                     </text>
                 </g>
 
                 <!-- Longest Streak Label -->
                 <g transform='translate(331,84)'>
-                    <text x='81.5' y='32' stroke-width='0' text-anchor='middle' fill='{$theme["sideLabels"]}' stroke='none' style='font-family: \"Segoe UI\", Ubuntu, sans-serif; font-weight: 400; font-size: 14px; font-style: normal; opacity: 0; animation: fadein 0.5s linear forwards 1.3s'>
+                    <text x='81.5' y='32' stroke-width='0' text-anchor='middle' fill='{$theme["sideLabels"]}' stroke='none' font-family='\"Segoe UI\", Ubuntu, sans-serif' font-weight='400' font-size='14px' font-style='normal' style='opacity: 0; animation: fadein 0.5s linear forwards 1.3s'>
                         {$longestStreakText}
                     </text>
                 </g>
 
                 <!-- Longest Streak Range -->
                 <g transform='translate(331,114)'>
-                    <text x='81.5' y='32' stroke-width='0' text-anchor='middle' fill='{$theme["dates"]}' stroke='none' style='font-family: \"Segoe UI\", Ubuntu, sans-serif; font-weight: 400; font-size: 12px; font-style: normal; opacity: 0; animation: fadein 0.5s linear forwards 1.4s'>
+                    <text x='81.5' y='32' stroke-width='0' text-anchor='middle' fill='{$theme["dates"]}' stroke='none' font-family='\"Segoe UI\", Ubuntu, sans-serif' font-weight='400' font-size='12px' font-style='normal' style='opacity: 0; animation: fadein 0.5s linear forwards 1.4s'>
                         {$longestStreakRange}
                     </text>
                 </g>
@@ -399,7 +399,7 @@ function generateErrorCard(string $message, array $params = null): string
             <g style='isolation: isolate'>
                 <!-- Error Label -->
                 <g transform='translate(166,108)'>
-                    <text x='81.5' y='50' dy='0.25em' stroke-width='0' text-anchor='middle' fill='{$theme["sideLabels"]}' stroke='none' style='font-family: \"Segoe UI\", Ubuntu, sans-serif; font-weight: 400; font-size: 14px; font-style: normal'>
+                    <text x='81.5' y='50' dy='0.25em' stroke-width='0' text-anchor='middle' fill='{$theme["sideLabels"]}' stroke='none' font-family='\"Segoe UI\", Ubuntu, sans-serif' font-weight='400' font-size='14px' font-style='normal'>
                         {$message}
                     </text>
                 </g>

--- a/tests/expected/test_card.svg
+++ b/tests/expected/test_card.svg
@@ -31,21 +31,21 @@
             <g style='isolation: isolate'>
                 <!-- Total Contributions Big Number -->
                 <g transform='translate(1,48)'>
-                    <text x='81.5' y='32' stroke-width='0' text-anchor='middle' fill='#666666' stroke='none' style='font-family: "Segoe UI", Ubuntu, sans-serif; font-weight: 700; font-size: 28px; font-style: normal; opacity: 0; animation: fadein 0.5s linear forwards 0.6s'>
+                    <text x='81.5' y='32' stroke-width='0' text-anchor='middle' fill='#666666' stroke='none' font-family='"Segoe UI", Ubuntu, sans-serif' font-weight='700' font-size='28px' font-style='normal' style='opacity: 0; animation: fadein 0.5s linear forwards 0.6s'>
                         2,048
                     </text>
                 </g>
 
                 <!-- Total Contributions Label -->
                 <g transform='translate(1,84)'>
-                    <text x='81.5' y='32' stroke-width='0' text-anchor='middle' fill='#888888' stroke='none' style='font-family: "Segoe UI", Ubuntu, sans-serif; font-weight: 400; font-size: 14px; font-style: normal; opacity: 0; animation: fadein 0.5s linear forwards 0.7s'>
+                    <text x='81.5' y='32' stroke-width='0' text-anchor='middle' fill='#888888' stroke='none' font-family='"Segoe UI", Ubuntu, sans-serif' font-weight='400' font-size='14px' font-style='normal' style='opacity: 0; animation: fadein 0.5s linear forwards 0.7s'>
                         Total Contributions
                     </text>
                 </g>
 
                 <!-- total contributions range -->
                 <g transform='translate(1,114)'>
-                    <text x='81.5' y='32' stroke-width='0' text-anchor='middle' fill='#999999' stroke='none' style='font-family: "Segoe UI", Ubuntu, sans-serif; font-weight: 400; font-size: 12px; font-style: normal; opacity: 0; animation: fadein 0.5s linear forwards 0.8s'>
+                    <text x='81.5' y='32' stroke-width='0' text-anchor='middle' fill='#999999' stroke='none' font-family='"Segoe UI", Ubuntu, sans-serif' font-weight='400' font-size='12px' font-style='normal' style='opacity: 0; animation: fadein 0.5s linear forwards 0.8s'>
                         Aug 10, 2016 - Present
                     </text>
                 </g>
@@ -53,21 +53,21 @@
             <g style='isolation: isolate'>
                 <!-- Current Streak Big Number -->
                 <g transform='translate(166,48)'>
-                    <text x='81.5' y='32' stroke-width='0' text-anchor='middle' fill='#555555' stroke='none' style='font-family: "Segoe UI", Ubuntu, sans-serif; font-weight: 700; font-size: 28px; font-style: normal; animation: currstreak 0.6s linear forwards'>
+                    <text x='81.5' y='32' stroke-width='0' text-anchor='middle' fill='#555555' stroke='none' font-family='"Segoe UI", Ubuntu, sans-serif' font-weight='700' font-size='28px' font-style='normal' style='animation: currstreak 0.6s linear forwards'>
                         16
                     </text>
                 </g>
 
                 <!-- Current Streak Label -->
                 <g transform='translate(166,108)'>
-                    <text x='81.5' y='32' stroke-width='0' text-anchor='middle' fill='#777777' stroke='none' style='font-family: "Segoe UI", Ubuntu, sans-serif; font-weight: 700; font-size: 14px; font-style: normal; opacity: 0; animation: fadein 0.5s linear forwards 0.9s'>
+                    <text x='81.5' y='32' stroke-width='0' text-anchor='middle' fill='#777777' stroke='none' font-family='"Segoe UI", Ubuntu, sans-serif' font-weight='700' font-size='14px' font-style='normal' style='opacity: 0; animation: fadein 0.5s linear forwards 0.9s'>
                         Current Streak
                     </text>
                 </g>
 
                 <!-- Current Streak Range -->
                 <g transform='translate(166,145)'>
-                    <text x='81.5' y='21' stroke-width='0' text-anchor='middle' fill='#999999' stroke='none' style='font-family: "Segoe UI", Ubuntu, sans-serif; font-weight: 400; font-size: 12px; font-style: normal; opacity: 0; animation: fadein 0.5s linear forwards 0.9s'>
+                    <text x='81.5' y='21' stroke-width='0' text-anchor='middle' fill='#999999' stroke='none' font-family='"Segoe UI", Ubuntu, sans-serif' font-weight='400' font-size='12px' font-style='normal' style='opacity: 0; animation: fadein 0.5s linear forwards 0.9s'>
                         Mar 28, 2019 - Apr 12, 2019
                     </text>
                 </g>
@@ -86,21 +86,21 @@
             <g style='isolation: isolate'>
                 <!-- Longest Streak Big Number -->
                 <g transform='translate(331,48)'>
-                    <text x='81.5' y='32' stroke-width='0' text-anchor='middle' fill='#666666' stroke='none' style='font-family: "Segoe UI", Ubuntu, sans-serif; font-weight: 700; font-size: 28px; font-style: normal; opacity: 0; animation: fadein 0.5s linear forwards 1.2s'>
+                    <text x='81.5' y='32' stroke-width='0' text-anchor='middle' fill='#666666' stroke='none' font-family='"Segoe UI", Ubuntu, sans-serif' font-weight='700' font-size='28px' font-style='normal' style='opacity: 0; animation: fadein 0.5s linear forwards 1.2s'>
                         86
                     </text>
                 </g>
 
                 <!-- Longest Streak Label -->
                 <g transform='translate(331,84)'>
-                    <text x='81.5' y='32' stroke-width='0' text-anchor='middle' fill='#888888' stroke='none' style='font-family: "Segoe UI", Ubuntu, sans-serif; font-weight: 400; font-size: 14px; font-style: normal; opacity: 0; animation: fadein 0.5s linear forwards 1.3s'>
+                    <text x='81.5' y='32' stroke-width='0' text-anchor='middle' fill='#888888' stroke='none' font-family='"Segoe UI", Ubuntu, sans-serif' font-weight='400' font-size='14px' font-style='normal' style='opacity: 0; animation: fadein 0.5s linear forwards 1.3s'>
                         Longest Streak
                     </text>
                 </g>
 
                 <!-- Longest Streak Range -->
                 <g transform='translate(331,114)'>
-                    <text x='81.5' y='32' stroke-width='0' text-anchor='middle' fill='#999999' stroke='none' style='font-family: "Segoe UI", Ubuntu, sans-serif; font-weight: 400; font-size: 12px; font-style: normal; opacity: 0; animation: fadein 0.5s linear forwards 1.4s'>
+                    <text x='81.5' y='32' stroke-width='0' text-anchor='middle' fill='#999999' stroke='none' font-family='"Segoe UI", Ubuntu, sans-serif' font-weight='400' font-size='12px' font-style='normal' style='opacity: 0; animation: fadein 0.5s linear forwards 1.4s'>
                         Dec 19, 2016 - Mar 14, 2016
                     </text>
                 </g>

--- a/tests/expected/test_error_card.svg
+++ b/tests/expected/test_error_card.svg
@@ -16,7 +16,7 @@
             <g style='isolation: isolate'>
                 <!-- Error Label -->
                 <g transform='translate(166,108)'>
-                    <text x='81.5' y='50' dy='0.25em' stroke-width='0' text-anchor='middle' fill='#888888' stroke='none' style='font-family: "Segoe UI", Ubuntu, sans-serif; font-weight: 400; font-size: 14px; font-style: normal'>
+                    <text x='81.5' y='50' dy='0.25em' stroke-width='0' text-anchor='middle' fill='#888888' stroke='none' font-family='"Segoe UI", Ubuntu, sans-serif' font-weight='400' font-size='14px' font-style='normal'>
                         An unknown error occurred
                     </text>
                 </g>


### PR DESCRIPTION
## Description

Uses font-family, font-weight, font-size, font-style as SVG attributes rather than in inline CSS

Related: #355 