### PR TITLE
fix: Skip graphs if contribution graph returns null

### DIFF
--- a/src/stats.php
+++ b/src/stats.php
@@ -199,7 +199,7 @@ function getContributionDates(array $contributionGraphs): array
             throw new AssertionError($graph->data->errors[0]->message, 502);
         }
         if (empty($graph)) {
-            throw new AssertionError("No data was returned from GitHub.", 502);
+            continue;
         }
         $weeks = $graph->data->user->contributionsCollection->contributionCalendar->weeks;
         foreach ($weeks as $week) {

--- a/src/stats.php
+++ b/src/stats.php
@@ -198,6 +198,9 @@ function getContributionDates(array $contributionGraphs): array
         if (!empty($graph->errors)) {
             throw new AssertionError($graph->data->errors[0]->message, 502);
         }
+        if (empty($graph)) {
+            throw new AssertionError("No data was returned from GitHub.", 502);
+        }
         $weeks = $graph->data->user->contributionsCollection->contributionCalendar->weeks;
         foreach ($weeks as $week) {
             foreach ($week->contributionDays as $day) {


### PR DESCRIPTION
Prevents some errors from appearing in the logs