### PR TITLE
docs(readme): Add links to line numbers for locales

### DIFF
--- a/scripts/translation-progress.php
+++ b/scripts/translation-progress.php
@@ -19,6 +19,7 @@ function getProgress(array $translations): array
         "Present",
     ];
 
+    $translations_file = file(__DIR__ . "/../src/translations.php");
     $progress = [];
     foreach ($translations as $locale => $phrases) {
         $translated = 0;
@@ -29,10 +30,12 @@ function getProgress(array $translations): array
         }
         $percentage = round(($translated / count($phrases_to_translate)) * 100);
         $locale_name = Locale::getDisplayName($locale, $locale);
+        $line_number = getLineNumber($translations_file, $locale);
         $progress[$locale] = [
             "locale" => $locale,
             "locale_name" => $locale_name,
             "percentage" => $percentage,
+            "line_number" => $line_number,
         ];
     }
     // sort by percentage
@@ -40,6 +43,18 @@ function getProgress(array $translations): array
         return $b["percentage"] <=> $a["percentage"];
     });
     return $progress;
+}
+
+/**
+ * Get the line number of the locale in the translations file
+ *
+ * @param array $translations_file The translations file
+ * @param string $locale The locale
+ * @return int The line number of the locale in the translations file
+ */
+function getLineNumber(array $translations_file, string $locale): int
+{
+    return key(preg_grep("/^\\s*\"$locale\"\\s*=>\\s*\\[/", $translations_file)) + 1;
 }
 
 /**
@@ -55,7 +70,8 @@ function progressToBadges(array $progress): string
     $badges .= str_repeat("| --- ", $per_row) . "|" . "\n";
     $i = 0;
     foreach (array_values($progress) as $data) {
-        $badges .= "| `{$data["locale"]}` - {$data["locale_name"]} <br /> ![{$data["locale_name"]} {$data["percentage"]}%](https://progress-bar.dev/{$data["percentage"]}) ";
+        $line_url = "https://github.com/DenverCoder1/github-readme-streak-stats/blob/main/src/translations.php#L{$data["line_number"]}";
+        $badges .= "| `{$data["locale"]}` - {$data["locale_name"]} <br /> [![{$data["locale_name"]} {$data["percentage"]}%](https://progress-bar.dev/{$data["percentage"]})]($line_url) ";
         $i++;
         if ($i % $per_row === 0) {
             $badges .= "|\n";

--- a/scripts/translation-progress.php
+++ b/scripts/translation-progress.php
@@ -71,7 +71,7 @@ function progressToBadges(array $progress): string
     $i = 0;
     foreach (array_values($progress) as $data) {
         $line_url = "https://github.com/DenverCoder1/github-readme-streak-stats/blob/main/src/translations.php#L{$data["line_number"]}";
-        $badges .= "| `{$data["locale"]}` - {$data["locale_name"]} <br /> [![{$data["locale_name"]} {$data["percentage"]}%](https://progress-bar.dev/{$data["percentage"]})]($line_url) ";
+        $badges .= "| [`{$data["locale"]}`]({$line_url}) - {$data["locale_name"]} <br /> [![{$data["locale_name"]} {$data["percentage"]}%](https://progress-bar.dev/{$data["percentage"]})]({$line_url}) ";
         $i++;
         if ($i % $per_row === 0) {
             $badges .= "|\n";


### PR DESCRIPTION
## Description

Make progress bars and locales link to line numbers in translations file

Fixes # <!-- add issue number -->

### Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (added a non-breaking change which fixes an issue)
- [ ] New feature (added a non-breaking change which adds functionality)
- [x] Updated documentation (updated the readme, templates, or other repo files)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

<!--
If you have changed a feature of the stats cards, please describe the tests you made to verify your changes.
Changes strictly related to documentation can skip this section.
-->

- [ ] Tested locally with a valid username
- [ ] Tested locally with an invalid username
- [ ] Ran tests with `composer test`
- [ ] Added or updated test cases to test new features

## Checklist:

- [ ] I have checked to make sure no other [pull requests](https://github.com/DenverCoder1/github-readme-streak-stats/pulls?q=is%3Apr+sort%3Aupdated-desc+) are open for this issue
- [ ] The code is properly formatted and is consistent with the existing code style
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

## Screenshots

<!-- If you have updated the design or appearance, please include a screenshot of your changes. -->
