### PR TITLE
fix: Reduce characters per line for side labels

### DIFF
--- a/src/card.php
+++ b/src/card.php
@@ -242,13 +242,13 @@ function generateCard(array $stats, array $params = null): string
     }
 
     // if the translations contain a newline, split the text into two tspan elements
-    $totalContributionsText = splitLines($localeTranslations["Total Contributions"], 24, -9);
+    $totalContributionsText = splitLines($localeTranslations["Total Contributions"], 22, -9);
     if ($stats["mode"] === "weekly") {
         $currentStreakText = splitLines($localeTranslations["Week Streak"], 22, -9);
-        $longestStreakText = splitLines($localeTranslations["Longest Week Streak"], 24, -9);
+        $longestStreakText = splitLines($localeTranslations["Longest Week Streak"], 22, -9);
     } else {
         $currentStreakText = splitLines($localeTranslations["Current Streak"], 22, -9);
-        $longestStreakText = splitLines($localeTranslations["Longest Streak"], 24, -9);
+        $longestStreakText = splitLines($localeTranslations["Longest Streak"], 22, -9);
     }
 
     // if the ranges contain over 28 characters, split the text into two tspan elements


### PR DESCRIPTION
## Description

Lines will wrap at 22 characters instead of 24 to avoid text too close to edges, for example with Longest Week Streak in Spanish.

![image](https://user-images.githubusercontent.com/20955511/206339407-37cee00b-abd5-4b1b-acfa-cd6526e56e32.png)

![image](https://user-images.githubusercontent.com/20955511/206339418-5b3f0889-8b61-47d8-a63f-c5641784ba76.png)

### Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (added a non-breaking change which fixes an issue)
- [ ] New feature (added a non-breaking change which adds functionality)
- [ ] Updated documentation (updated the readme, templates, or other repo files)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

<!--
If you have changed a feature of the stats cards, please describe the tests you made to verify your changes.
Changes strictly related to documentation can skip this section.
-->

- [x] Tested locally with a valid username
- [ ] Tested locally with an invalid username
- [x] Ran tests with `composer test`
- [x] Added or updated test cases to test new features

## Checklist:

- [ ] I have checked to make sure no other [pull requests](https://github.com/DenverCoder1/github-readme-streak-stats/pulls?q=is%3Apr+sort%3Aupdated-desc+) are open for this issue
- [ ] The code is properly formatted and is consistent with the existing code style
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

## Screenshots

<!-- If you have updated the design or appearance, please include a screenshot of your changes. -->
