### PR TITLE
fix: Parse error when user passed contains quotes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ node_modules/
 composer.phar
 yarn.lock
 package-lock.json
+.vercel
 
 # Local Configuration
 package.json

--- a/src/index.php
+++ b/src/index.php
@@ -32,7 +32,7 @@ if (!isset($_REQUEST["user"])) {
 
 try {
     // get streak stats for user given in query string
-    $user = preg_replace("/[^a-zA-Z0-9_\.\-]/", "", $_REQUEST["user"]);
+    $user = preg_replace("/[^a-zA-Z0-9_\-]/", "", $_REQUEST["user"]);
     $contributionGraphs = getContributionGraphs($user);
     $contributions = getContributionDates($contributionGraphs);
     if (isset($_GET["mode"]) && $_GET["mode"] === "weekly") {

--- a/src/index.php
+++ b/src/index.php
@@ -32,7 +32,8 @@ if (!isset($_REQUEST["user"])) {
 
 try {
     // get streak stats for user given in query string
-    $contributionGraphs = getContributionGraphs($_REQUEST["user"]);
+    $user = preg_replace("/[^a-zA-Z0-9_\.\-]/", "", $_REQUEST["user"]);
+    $contributionGraphs = getContributionGraphs($user);
     $contributions = getContributionDates($contributionGraphs);
     if (isset($_GET["mode"]) && $_GET["mode"] === "weekly") {
         $stats = getWeeklyContributionStats($contributions);

--- a/src/index.php
+++ b/src/index.php
@@ -32,7 +32,7 @@ if (!isset($_REQUEST["user"])) {
 
 try {
     // get streak stats for user given in query string
-    $user = preg_replace("/[^a-zA-Z0-9_\-]/", "", $_REQUEST["user"]);
+    $user = preg_replace("/[^a-zA-Z0-9\-]/", "", $_REQUEST["user"]);
     $contributionGraphs = getContributionGraphs($user);
     $contributions = getContributionDates($contributionGraphs);
     if (isset($_GET["mode"]) && $_GET["mode"] === "weekly") {

--- a/src/stats.php
+++ b/src/stats.php
@@ -191,13 +191,14 @@ function getContributionYears(string $user): array
     }";
     $response = fetchGraphQL($query);
     // User not found
-    if (!empty($response->errors) && $response->errors[0]->type === "NOT_FOUND") {
-        throw new InvalidArgumentException("Could not find a user with that name.", 404);
-    }
-    // API Error
     if (!empty($response->errors)) {
+        $type = $response->errors[0]->type ?? "";
+        if ($type === "NOT_FOUND") {
+            throw new InvalidArgumentException("Could not find a user with that name.", 404);
+        }
+        $message = $response->errors[0]->message ?? "An API error occurred.";
         // Other errors that contain a message field
-        throw new InvalidArgumentException($response->errors[0]->message, 500);
+        throw new InvalidArgumentException($message, 500);
     }
     // API did not return data
     if (!isset($response->data) && isset($response->message)) {


### PR DESCRIPTION
## Description

Fixes parse error for usernames containing quotes

![image](https://user-images.githubusercontent.com/20955511/206931743-49b9c654-2a65-4b77-a470-4e96a3679b1c.png)

The username is sanitized to only allow letters, numbers, dashes

### Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (added a non-breaking change which fixes an issue)
- [ ] New feature (added a non-breaking change which adds functionality)
- [ ] Updated documentation (updated the readme, templates, or other repo files)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

<!--
If you have changed a feature of the stats cards, please describe the tests you made to verify your changes.
Changes strictly related to documentation can skip this section.
-->

- [ ] Tested locally with a valid username
- [ ] Tested locally with an invalid username
- [ ] Ran tests with `composer test`
- [ ] Added or updated test cases to test new features

## Checklist:

- [ ] I have checked to make sure no other [pull requests](https://github.com/DenverCoder1/github-readme-streak-stats/pulls?q=is%3Apr+sort%3Aupdated-desc+) are open for this issue
- [ ] The code is properly formatted and is consistent with the existing code style
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

## Screenshots

<!-- If you have updated the design or appearance, please include a screenshot of your changes. -->
