### PR TITLE
fix: API error not passing message

### DIFF
--- a/src/demo/preview.php
+++ b/src/demo/preview.php
@@ -44,5 +44,9 @@ header("Content-Type: image/svg+xml");
 try {
     renderOutput($demoStats);
 } catch (InvalidArgumentException | AssertionError $error) {
+    error_log("Error {$error->getCode()}: {$error->getMessage()}");
+    if ($error->getCode() >= 500) {
+        error_log($error->getTraceAsString());
+    }
     renderOutput($error->getMessage(), $error->getCode());
 }

--- a/src/index.php
+++ b/src/index.php
@@ -42,5 +42,9 @@ try {
     }
     renderOutput($stats);
 } catch (InvalidArgumentException | AssertionError $error) {
+    error_log("Error {$error->getCode()}: {$error->getMessage()}");
+    if ($error->getCode() >= 500) {
+        error_log($error->getTraceAsString());
+    }
     renderOutput($error->getMessage(), $error->getCode());
 }

--- a/src/stats.php
+++ b/src/stats.php
@@ -224,7 +224,7 @@ function getContributionDates(array $contributionGraphs): array
     ksort($contributionGraphs);
     foreach ($contributionGraphs as $graph) {
         if (empty($graph->data)) {
-            $message = $graph->errors[0]->message ?? $graph->message ?? "An API error occurred.";
+            $message = $graph->errors[0]->message ?? ($graph->message ?? "An API error occurred.");
             throw new InvalidArgumentException($message, 502);
         }
         $weeks = $graph->data->user->contributionsCollection->contributionCalendar->weeks;

--- a/src/stats.php
+++ b/src/stats.php
@@ -223,8 +223,8 @@ function getContributionDates(array $contributionGraphs): array
     // sort contribution calendars by year key
     ksort($contributionGraphs);
     foreach ($contributionGraphs as $graph) {
-        if (!empty($graph->errors)) {
-            $message = $graph->errors[0]->message ?? "A GitHub API error occurred.";
+        if (empty($graph->data)) {
+            $message = $graph->errors[0]->message ?? $graph->message ?? "An API error occurred.";
             throw new InvalidArgumentException($message, 502);
         }
         $weeks = $graph->data->user->contributionsCollection->contributionCalendar->weeks;

--- a/src/stats.php
+++ b/src/stats.php
@@ -64,13 +64,13 @@ function getContributionGraphs(string $user): array
     $response = [];
     foreach ($requests as $year => $request) {
         $contents = curl_multi_getcontent($request);
-        $decoded = json_decode($contents);
+        $decoded = is_string($contents) ? json_decode($contents) : null;
         // if response is empty or invalid, retry request one time
         if (empty($decoded) || empty($decoded->data)) {
             $query = buildContributionGraphQuery($user, $year);
             $request = getGraphQLCurlHandle($query);
             $contents = curl_exec($request);
-            $decoded = json_decode($contents);
+            $decoded = is_string($contents) ? json_decode($contents) : null;
             // if the response is still empty or invalid, log an error and skip the year
             if (empty($decoded) || empty($decoded->data)) {
                 $message = $decoded->errors[0]->message ?? ($decoded->message ?? "An API error occurred.");

--- a/src/stats.php
+++ b/src/stats.php
@@ -197,7 +197,6 @@ function getContributionYears(string $user): array
             throw new InvalidArgumentException("Could not find a user with that name.", 404);
         }
         $message = $response->errors[0]->message ?? "An API error occurred.";
-        $message = trim("$type $message");
         // Other errors that contain a message field
         throw new InvalidArgumentException($message, 502);
     }
@@ -225,9 +224,7 @@ function getContributionDates(array $contributionGraphs): array
     ksort($contributionGraphs);
     foreach ($contributionGraphs as $graph) {
         if (!empty($graph->errors)) {
-            $type = $graph->errors[0]->type ?? "";
-            $message = $graph->errors[0]->message ?? "An API error occurred.";
-            $message = trim("$type $message");
+            $message = $graph->errors[0]->message ?? "A GitHub API error occurred.";
             throw new InvalidArgumentException($message, 502);
         }
         $weeks = $graph->data->user->contributionsCollection->contributionCalendar->weeks;

--- a/src/stats.php
+++ b/src/stats.php
@@ -71,15 +71,11 @@ function getContributionGraphs(string $user): array
             $request = getGraphQLCurlHandle($query);
             $contents = curl_exec($request);
             $decoded = json_decode($contents);
-            // if the response is still empty, log an error and skip the year
-            if (empty($decoded)) {
-                error_log("Failed to decode response for $user's $year contributions after 2 attempts.");
-                continue;
-            }
-            // if the response is still invalid, throw an error
-            if (empty($decoded->data)) {
+            // if the response is still empty or invalid, log an error and skip the year
+            if (empty($decoded) || empty($decoded->data)) {
                 $message = $decoded->errors[0]->message ?? ($decoded->message ?? "An API error occurred.");
-                throw new InvalidArgumentException($message, 502);
+                error_log("Failed to decode response for $user's $year contributions after 2 attempts. $message");
+                continue;
             }
         }
         array_unshift($response, $decoded);

--- a/src/stats.php
+++ b/src/stats.php
@@ -197,8 +197,9 @@ function getContributionYears(string $user): array
             throw new InvalidArgumentException("Could not find a user with that name.", 404);
         }
         $message = $response->errors[0]->message ?? "An API error occurred.";
+        $message = trim("$type $message");
         // Other errors that contain a message field
-        throw new InvalidArgumentException($message, 500);
+        throw new InvalidArgumentException($message, 502);
     }
     // API did not return data
     if (!isset($response->data) && isset($response->message)) {
@@ -224,7 +225,10 @@ function getContributionDates(array $contributionGraphs): array
     ksort($contributionGraphs);
     foreach ($contributionGraphs as $graph) {
         if (!empty($graph->errors)) {
-            throw new AssertionError($graph->data->errors[0]->message, 502);
+            $type = $graph->errors[0]->type ?? "";
+            $message = $graph->errors[0]->message ?? "An API error occurred.";
+            $message = trim("$type $message");
+            throw new InvalidArgumentException($message, 502);
         }
         $weeks = $graph->data->user->contributionsCollection->contributionCalendar->weeks;
         foreach ($weeks as $week) {


### PR DESCRIPTION
## Description

NULL was gettng passed as the error message when a GitHub API error occurred while fetching a graph

Fixes #379 

### Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (added a non-breaking change which fixes an issue)
- [ ] New feature (added a non-breaking change which adds functionality)
- [ ] Updated documentation (updated the readme, templates, or other repo files)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

<!--
If you have changed a feature of the stats cards, please describe the tests you made to verify your changes.
Changes strictly related to documentation can skip this section.
-->

- [ ] Tested locally with a valid username
- [ ] Tested locally with an invalid username
- [ ] Ran tests with `composer test`
- [ ] Added or updated test cases to test new features

## Checklist:

- [ ] I have checked to make sure no other [pull requests](https://github.com/DenverCoder1/github-readme-streak-stats/pulls?q=is%3Apr+sort%3Aupdated-desc+) are open for this issue
- [ ] The code is properly formatted and is consistent with the existing code style
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

## Screenshots

<!-- If you have updated the design or appearance, please include a screenshot of your changes. -->
