### PR TITLE
Fixed persian translation

### DIFF
--- a/src/translations.php
+++ b/src/translations.php
@@ -74,11 +74,11 @@ return [
     "fa" => [
         "rtl" => true,
         "Total Contributions" => "مجموع مشارکت ها",
-        "Current Streak" => "رگه فعلی",
-        "Longest Streak" => "طولانی ترین رگه",
-        "Week Streak" => "هفته رگه",
-        "Longest Week Streak" => "طولانی ترین هفته",
-        "Present" => "حاضر",
+        "Current Streak" => "پی‌رفت فعلی",
+        "Longest Streak" => "طولانی ترین پی‌رفت",
+        "Week Streak" => "پی‌رفت هفته",
+        "Longest Week Streak" => "طولانی ترین پی‌رفت هفته",
+        "Present" => "اکنون",
     ],
     "fr" => [
         "Total Contributions" => "Contributions totales",


### PR DESCRIPTION
Fixed persian translation for "sequence" and "present"

## Description

#### Modified the translation for Persian/Farsi (fa).

Fixed persian translation for "sequence" and "present". There was also a switched phrase translation.
The translation looked like it was made by machine translation. 

Ref: #236 

### Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (added a non-breaking change which fixes an issue)
- [ ] New feature (added a non-breaking change which adds functionality)
- [x] Updated documentation (updated the readme, templates, or other repo files)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have checked to make sure no other [pull requests](https://github.com/DenverCoder1/github-readme-streak-stats/pulls?q=is%3Apr+sort%3Aupdated-desc+) are open for this issue
- [x] The code is properly formatted and is consistent with the existing code style
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
