### PR TITLE
fix: Only decode json if it's a string

### DIFF
--- a/src/stats.php
+++ b/src/stats.php
@@ -155,7 +155,7 @@ function fetchGraphQL(string $query): stdClass
     $ch = getGraphQLCurlHandle($query);
     $response = curl_exec($ch);
     curl_close($ch);
-    $obj = json_decode($response);
+    $obj = is_string($response) ? json_decode($response) : null;
     // handle curl errors
     if ($response === false || $obj === null || curl_getinfo($ch, CURLINFO_HTTP_CODE) >= 400) {
         // set response code to curl error code


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. -->

Fixes # <!-- add issue number -->

### Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (added a non-breaking change which fixes an issue)
- [ ] New feature (added a non-breaking change which adds functionality)
- [ ] Updated documentation (updated the readme, templates, or other repo files)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

<!--
If you have changed a feature of the stats cards, please describe the tests you made to verify your changes.
Changes strictly related to documentation can skip this section.
-->

- [ ] Tested locally with a valid username
- [ ] Tested locally with an invalid username
- [ ] Ran tests with `composer test`
- [ ] Added or updated test cases to test new features

## Checklist:

- [ ] I have checked to make sure no other [pull requests](https://github.com/DenverCoder1/github-readme-streak-stats/pulls?q=is%3Apr+sort%3Aupdated-desc+) are open for this issue
- [ ] The code is properly formatted and is consistent with the existing code style
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

## Screenshots

<!-- If you have updated the design or appearance, please include a screenshot of your changes. -->
