### PR TITLE
fix: Updated French translation of `Longest Week Streak`

### DIFF
--- a/src/translations.php
+++ b/src/translations.php
@@ -98,7 +98,7 @@ return [
         "Current Streak" => "Séquence actuelle",
         "Longest Streak" => "Plus longue séquence",
         "Week Streak" => "Séquence de la semaine",
-        "Longest Week Streak" => "Plus longue de semaine séquence",
+        "Longest Week Streak" => "Plus longue séquence hebdomadaire",
         "Present" => "Aujourd'hui",
     ],
     "he" => [


### PR DESCRIPTION
## Description
The translation of `Longest Week Streak` was `Plus longue de semaine séquence`. This is not grammatically correct in French, which is why I propose this fix by replacing it with `Plus longue séquence hebdomadaire`.

### Type of change

- [x ] Bug fix (added a non-breaking change which fixes an issue)

## How Has This Been Tested?

- [ ] Tested locally with a valid username
- [ ] Tested locally with an invalid username
- [ ] Ran tests with `composer test`
- [ ] Added or updated test cases to test new features

## Checklist:

- [x] I have checked to make sure no other [pull requests](https://github.com/DenverCoder1/github-readme-streak-stats/pulls?q=is%3Apr+sort%3Aupdated-desc+) are open for this issue
- [x] The code is properly formatted and is consistent with the existing code style
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings