### PR TITLE
Do not add advanced prop on submit

### DIFF
--- a/src/demo/index.php
+++ b/src/demo/index.php
@@ -146,7 +146,7 @@ function camelToSkewer(string $str): string
                                 <option><?php echo $option; ?></option>
                             <?php endforeach; ?>
                         </select>
-                        <button class="plus btn" onclick="return preview.addProperty()">+</button>
+                        <button class="plus btn" type="button" onclick="return preview.addProperty()">+</button>
                     </div>
                     <button class="btn" type="button" onclick='return preview.exportPhp()'>Export to PHP</button>
                     <textarea id="exportedPhp" hidden></textarea>

--- a/src/demo/index.php
+++ b/src/demo/index.php
@@ -106,7 +106,7 @@ function camelToSkewer(string $str): string
                     <option>false</option>
                     <option>true</option>
                 </select>
-                
+
                 <label for="border_radius">Border Radius</label>
                 <input class="param" type="number" id="border_radius" name="border_radius" placeholder="4.5" value="4.5" step="0.1">
 
@@ -146,7 +146,7 @@ function camelToSkewer(string $str): string
                                 <option><?php echo $option; ?></option>
                             <?php endforeach; ?>
                         </select>
-                        <button class="plus btn" onclick="return preview.addProperty();">+</button>
+                        <button class="plus btn" onclick="return preview.addProperty()">+</button>
                     </div>
                     <button class="btn" type="button" onclick='return preview.exportPhp()'>Export to PHP</button>
                     <textarea id="exportedPhp" hidden></textarea>

--- a/src/demo/index.php
+++ b/src/demo/index.php
@@ -152,7 +152,7 @@ function camelToSkewer(string $str): string
                     <textarea id="exportedPhp" hidden></textarea>
                 </details>
 
-                <input class="btn" type="submit" value="Open Permalink">
+                <button class="btn" type="submit">Open Permalink</button>
             </form>
         </div>
 

--- a/src/demo/index.php
+++ b/src/demo/index.php
@@ -148,7 +148,7 @@ function camelToSkewer(string $str): string
                         </select>
                         <button class="plus btn" type="button" onclick="return preview.addProperty()">+</button>
                     </div>
-                    <button class="btn" type="button" onclick='return preview.exportPhp()'>Export to PHP</button>
+                    <button class="btn" type="button" onclick="return preview.exportPhp()">Export to PHP</button>
                     <textarea id="exportedPhp" hidden></textarea>
                 </details>
 

--- a/src/demo/js/script.js
+++ b/src/demo/js/script.js
@@ -80,6 +80,7 @@ const preview = {
       const minus = document.createElement("button");
       minus.className = "minus btn";
       minus.setAttribute("onclick", "return preview.removeProperty(this.getAttribute('data-property'));");
+      minus.setAttribute("type", "button");
       minus.innerText = "−";
       minus.setAttribute("data-property", propertyName);
       // add elements


### PR DESCRIPTION
## Description
* maps option colors with default ones
* does not set advanced prop on submit

Fixes #432 

### Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (added a non-breaking change which fixes an issue)
- [ ] New feature (added a non-breaking change which adds functionality)
- [ ] Updated documentation (updated the readme, templates, or other repo files)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

<!--
If you have changed a feature of the stats cards, please describe the tests you made to verify your changes.
Changes strictly related to documentation can skip this section.
-->

- [x] Tested locally with a valid username
- [x] Tested locally with an invalid username
- [x] Ran tests with `composer test`
- [ ] Added or updated test cases to test new features

## Checklist:

- [x] I have checked to make sure no other [pull requests](https://github.com/DenverCoder1/github-readme-streak-stats/pulls?q=is%3Apr+sort%3Aupdated-desc+) are open for this issue
- [x] The code is properly formatted and is consistent with the existing code style
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Screenshots
N/A
