### PR TITLE
fix: workaround for transparent background in PNG mode

### DIFF
--- a/src/card.php
+++ b/src/card.php
@@ -494,6 +494,11 @@ function convertSvgToPng(string $svg): string
     $svg = preg_replace("/(animation: currstreak[^;'\"]+)/m", "font-size: 28px;", $svg);
     $svg = preg_replace("/<a \X*?>(\X*?)<\/a>/m", '\1', $svg);
 
+    // replace all fully transparent colors in fill or stroke with "none"
+    // this is a workaround for what seems to be a bug in inkscape where rgba alpha values are ignored
+    // TODO: find a way to make partially transparent colors work (eg. #ffffff50)
+    $svg = preg_replace("/(fill|stroke)=['\"](#[0-9a-fA-F]{6}00|#[0-9a-fA-F]{3}0|transparent)['\"]/m", '\1="none"', $svg);
+
     // escape svg for shell
     $svg = escapeshellarg($svg);
 

--- a/src/card.php
+++ b/src/card.php
@@ -497,7 +497,11 @@ function convertSvgToPng(string $svg): string
     // replace all fully transparent colors in fill or stroke with "none"
     // this is a workaround for what seems to be a bug in inkscape where rgba alpha values are ignored
     // TODO: find a way to make partially transparent colors work (eg. #ffffff50)
-    $svg = preg_replace("/(fill|stroke)=['\"](#[0-9a-fA-F]{6}00|#[0-9a-fA-F]{3}0|transparent)['\"]/m", '\1="none"', $svg);
+    $svg = preg_replace(
+        "/(fill|stroke)=['\"](#[0-9a-fA-F]{6}00|#[0-9a-fA-F]{3}0|transparent)['\"]/m",
+        '\1="none"',
+        $svg
+    );
 
     // escape svg for shell
     $svg = escapeshellarg($svg);

--- a/src/card.php
+++ b/src/card.php
@@ -498,7 +498,7 @@ function convertSvgToPng(string $svg): string
     // this is a workaround for what seems to be a bug in inkscape where rgba alpha values are ignored
     // TODO: find a way to make partially transparent colors work (eg. #ffffff50)
     $svg = preg_replace(
-        "/(fill|stroke)=['\"](#[0-9a-fA-F]{6}00|#[0-9a-fA-F]{3}0|transparent)['\"]/m",
+        "/(fill|stroke)=['\"](?:#[0-9a-fA-F]{6}00|#[0-9a-fA-F]{3}0|transparent)['\"]/m",
         '\1="none"',
         $svg
     );


### PR DESCRIPTION
## Description

Allows background and stroke colors specified as "#xxxxxx00" or "#xxx0" to appear transparent instead of black when type is set to PNG. Setting the color to "transparent" works as well.

### Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (added a non-breaking change which fixes an issue)
- [ ] New feature (added a non-breaking change which adds functionality)
- [ ] Updated documentation (updated the readme, templates, or other repo files)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

<!--
If you have changed a feature of the stats cards, please describe the tests you made to verify your changes.
Changes strictly related to documentation can skip this section.
-->

- [ ] Tested locally with a valid username
- [ ] Tested locally with an invalid username
- [ ] Ran tests with `composer test`
- [ ] Added or updated test cases to test new features

## Checklist:

- [ ] I have checked to make sure no other [pull requests](https://github.com/DenverCoder1/github-readme-streak-stats/pulls?q=is%3Apr+sort%3Aupdated-desc+) are open for this issue
- [ ] The code is properly formatted and is consistent with the existing code style
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

## Screenshots

<!-- If you have updated the design or appearance, please include a screenshot of your changes. -->
