### PR TITLE
fix: Use fill-opacity and stroke-opacity for hex colors with alpha

### DIFF
--- a/tests/RenderTest.php
+++ b/tests/RenderTest.php
@@ -150,4 +150,30 @@ final class RenderTest extends TestCase
         $this->assertStringNotContainsString("animation:", $render);
         $this->assertStringNotContainsString("<style>", $render);
     }
+
+    /**
+     * Test alpha in hex colors
+     */
+    public function testAlphaInHexColors(): void
+    {
+        // "tranparent" gets converted to "#0000"
+        $this->testParams["background"] = "transparent";
+        $render = generateOutput($this->testStats, $this->testParams)["body"];
+        $this->assertStringContainsString("fill='#000000' fill-opacity='0'", $render);
+
+        // "#ff000080" gets converted to "#ff0000" and fill-opacity is set to 0.50196078431373
+        $this->testParams["background"] = "ff000080";
+        $render = generateOutput($this->testStats, $this->testParams)["body"];
+        $this->assertStringContainsString("fill='#ff0000' fill-opacity='0.50196078431373'", $render);
+
+        // "#ff0000" gets converted to "#ff0000" and fill-opacity is not set
+        $this->testParams["background"] = "ff0000ff";
+        $render = generateOutput($this->testStats, $this->testParams)["body"];
+        $this->assertStringContainsString("fill='#ff0000' fill-opacity='1'", $render);
+
+        // test stroke opacity
+        $this->testParams["border"] = "00ff0080";
+        $render = generateOutput($this->testStats, $this->testParams)["body"];
+        $this->assertStringContainsString("stroke='#00ff00' stroke-opacity='0.50196078431373'", $render);
+    }
 }


### PR DESCRIPTION
## Description

Adds support for hex colors in the format #rgba / #rrggbbaa where aa is the opacity (00-FF) when converting to PNG.

Inkscape does not currently support the #rgba / #rrggbbaa syntax - see https://gitlab.com/inkscape/inbox/-/issues/8215

Other SVG renderers may also have issues with certain colors fixed.

### Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (added a non-breaking change which fixes an issue)
- [ ] New feature (added a non-breaking change which adds functionality)
- [ ] Updated documentation (updated the readme, templates, or other repo files)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

<!--
If you have changed a feature of the stats cards, please describe the tests you made to verify your changes.
Changes strictly related to documentation can skip this section.
-->

- [ ] Tested locally with a valid username
- [ ] Tested locally with an invalid username
- [ ] Ran tests with `composer test`
- [ ] Added or updated test cases to test new features

## Checklist:

- [ ] I have checked to make sure no other [pull requests](https://github.com/DenverCoder1/github-readme-streak-stats/pulls?q=is%3Apr+sort%3Aupdated-desc+) are open for this issue
- [ ] The code is properly formatted and is consistent with the existing code style
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

## Screenshots

<!-- If you have updated the design or appearance, please include a screenshot of your changes. -->
