### PR TITLE
feat: Add "transparent" theme

### DIFF
--- a/docs/themes.md
+++ b/docs/themes.md
@@ -9,6 +9,7 @@ You can also try out and customize these themes on the [Demo Site](https://strea
 |           `default`           | ![image](https://user-images.githubusercontent.com/107488620/183304039-a1fcf05c-0112-493a-9188-778708dc9e8f.png) |
 |            `dark`             | ![image](https://user-images.githubusercontent.com/107488620/183304038-2788ab5d-4c02-45e9-a724-990f27061c54.png) |
 |        `highcontrast`         | ![image](https://user-images.githubusercontent.com/107488620/183304037-0e54b5e6-f39a-481d-806f-3369d257a391.png) |
+|         `transparent`         | ![image](https://user-images.githubusercontent.com/20955511/221571948-1b69a2cc-87af-4e96-83fa-f01278c22c33.png)  |
 |           `radical`           | ![image](https://user-images.githubusercontent.com/20955511/183303809-eb8fea2f-d56b-4ad3-9f6d-ef55f8812ed2.png)  |
 |            `merko`            | ![image](https://user-images.githubusercontent.com/20955511/183303806-4ce9e5bb-6bd7-4914-a4ff-47edee01bde3.png)  |
 |           `gruvbox`           | ![image](https://user-images.githubusercontent.com/20955511/183303804-95ff960f-ad52-4026-8627-a67f1599cee3.png)  |

--- a/src/themes.php
+++ b/src/themes.php
@@ -38,6 +38,18 @@ return [
         "sideLabels" => "#ffffff",
         "dates" => "#c5c5c5",
     ],
+    "transparent" => [
+        "background" => "#0000",
+        "border" => "#E4E2E2",
+        "stroke" => "#E4E2E2",
+        "ring" => "#006AFF",
+        "fire" => "#006AFF",
+        "currStreakNum" => "#0579C3",
+        "sideNums" => "#006AFF",
+        "currStreakLabel" => "#0579C3",
+        "sideLabels" => "#006AFF",
+        "dates" => "#417E87",
+    ],
     "radical" => [
         "background" => "#141321",
         "border" => "#e4e2e2",


### PR DESCRIPTION
## Description

Adds the "transparent" theme from [github-readme-stats](https://github.com/anuraghazra/github-readme-stats) to this project to allow for easier theme consistency.

Fixes #206 

### Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (added a non-breaking change which fixes an issue)
- [x] New feature (added a non-breaking change which adds functionality)
- [ ] Updated documentation (updated the readme, templates, or other repo files)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

<!--
If you have changed a feature of the stats cards, please describe the tests you made to verify your changes.
Changes strictly related to documentation can skip this section.
-->

- [ ] Tested locally with a valid username
- [ ] Tested locally with an invalid username
- [ ] Ran tests with `composer test`
- [ ] Added or updated test cases to test new features

## Checklist:

- [ ] I have checked to make sure no other [pull requests](https://github.com/DenverCoder1/github-readme-streak-stats/pulls?q=is%3Apr+sort%3Aupdated-desc+) are open for this issue
- [ ] The code is properly formatted and is consistent with the existing code style
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

## Screenshots

<!-- If you have updated the design or appearance, please include a screenshot of your changes. -->

![](https://github-readme-stats.vercel.app/api?username=anuraghazra&show_icons=true&theme=transparent)

![image](https://user-images.githubusercontent.com/20955511/221571948-1b69a2cc-87af-4e96-83fa-f01278c22c33.png)
