### PR TITLE
feat: Swap first and third columns when direction is rtl

### DIFF
--- a/src/card.php
+++ b/src/card.php
@@ -328,6 +328,12 @@ function generateCard(array $stats, array $params = null): string
     $centerOffset = $cardWidth / 2;
     $thirdColumnOffset = ($cardWidth * 5) / 6;
 
+    // if direction is rtl, swap first and third column offsets
+    if ($direction === "rtl") {
+        $firstColumnOffset = ($cardWidth * 5) / 6;
+        $thirdColumnOffset = $cardWidth / 6;
+    }
+
     // Set Background
     $backgroundParts = explode(",", $theme["background"] ?? "");
     $backgroundIsGradient = count($backgroundParts) >= 3;

--- a/src/card.php
+++ b/src/card.php
@@ -439,21 +439,21 @@ function generateCard(array $stats, array $params = null): string
                 <line x1='{$firstBarOffset}' y1='28' x2='{$firstBarOffset}' y2='170' vector-effect='non-scaling-stroke' stroke-width='1' stroke='{$theme["stroke"]}' stroke-linejoin='miter' stroke-linecap='square' stroke-miterlimit='3'/>
             </g>
             <g style='isolation: isolate'>
-                <!-- Total Contributions Big Number -->
+                <!-- Total Contributions big number -->
                 <g transform='translate({$firstColumnOffset},48)'>
                     <text x='0' y='32' stroke-width='0' text-anchor='middle' fill='{$theme["sideNums"]}' stroke='none' font-family='\"Segoe UI\", Ubuntu, sans-serif' font-weight='700' font-size='28px' font-style='normal' style='opacity: 0; animation: fadein 0.5s linear forwards 0.6s'>
                         {$totalContributions}
                     </text>
                 </g>
 
-                <!-- Total Contributions Label -->
+                <!-- Total Contributions label -->
                 <g transform='translate({$firstColumnOffset},84)'>
                     <text x='0' y='32' stroke-width='0' text-anchor='middle' fill='{$theme["sideLabels"]}' stroke='none' font-family='\"Segoe UI\", Ubuntu, sans-serif' font-weight='400' font-size='14px' font-style='normal' style='opacity: 0; animation: fadein 0.5s linear forwards 0.7s'>
                         {$totalContributionsText}
                     </text>
                 </g>
 
-                <!-- total contributions range -->
+                <!-- Total Contributions range -->
                 <g transform='translate({$firstColumnOffset},114)'>
                     <text x='0' y='32' stroke-width='0' text-anchor='middle' fill='{$theme["dates"]}' stroke='none' font-family='\"Segoe UI\", Ubuntu, sans-serif' font-weight='400' font-size='12px' font-style='normal' style='opacity: 0; animation: fadein 0.5s linear forwards 0.8s'>
                         {$totalContributionsRange}
@@ -461,32 +461,32 @@ function generateCard(array $stats, array $params = null): string
                 </g>
             </g>
             <g style='isolation: isolate'>
-                <!-- Current Streak Big Number -->
+                <!-- Current Streak big number -->
                 <g transform='translate({$centerOffset},48)'>
                     <text x='0' y='32' stroke-width='0' text-anchor='middle' fill='{$theme["currStreakNum"]}' stroke='none' font-family='\"Segoe UI\", Ubuntu, sans-serif' font-weight='700' font-size='28px' font-style='normal' style='animation: currstreak 0.6s linear forwards'>
                         {$currentStreak}
                     </text>
                 </g>
 
-                <!-- Current Streak Label -->
+                <!-- Current Streak label -->
                 <g transform='translate({$centerOffset},108)'>
                     <text x='0' y='32' stroke-width='0' text-anchor='middle' fill='{$theme["currStreakLabel"]}' stroke='none' font-family='\"Segoe UI\", Ubuntu, sans-serif' font-weight='700' font-size='14px' font-style='normal' style='opacity: 0; animation: fadein 0.5s linear forwards 0.9s'>
                         {$currentStreakText}
                     </text>
                 </g>
 
-                <!-- Current Streak Range -->
+                <!-- Current Streak range -->
                 <g transform='translate({$centerOffset},145)'>
                     <text x='0' y='21' stroke-width='0' text-anchor='middle' fill='{$theme["dates"]}' stroke='none' font-family='\"Segoe UI\", Ubuntu, sans-serif' font-weight='400' font-size='12px' font-style='normal' style='opacity: 0; animation: fadein 0.5s linear forwards 0.9s'>
                         {$currentStreakRange}
                     </text>
                 </g>
 
-                <!-- ring around number -->
+                <!-- Ring around number -->
                 <g mask='url(#mask_out_ring_behind_fire)'>
                     <circle cx='{$centerOffset}' cy='71' r='40' fill='none' stroke='{$theme["ring"]}' stroke-width='5' style='opacity: 0; animation: fadein 0.5s linear forwards 0.4s'></circle>
                 </g>
-                <!-- fire icon -->
+                <!-- Fire icon -->
                 <g transform='translate({$centerOffset}, 19.5)' stroke-opacity='0' style='opacity: 0; animation: fadein 0.5s linear forwards 0.6s'>
                     <path d='M -12 -0.5 L 15 -0.5 L 15 23.5 L -12 23.5 L -12 -0.5 Z' fill='none'/>
                     <path d='M 1.5 0.67 C 1.5 0.67 2.24 3.32 2.24 5.47 C 2.24 7.53 0.89 9.2 -1.17 9.2 C -3.23 9.2 -4.79 7.53 -4.79 5.47 L -4.76 5.11 C -6.78 7.51 -8 10.62 -8 13.99 C -8 18.41 -4.42 22 0 22 C 4.42 22 8 18.41 8 13.99 C 8 8.6 5.41 3.79 1.5 0.67 Z M -0.29 19 C -2.07 19 -3.51 17.6 -3.51 15.86 C -3.51 14.24 -2.46 13.1 -0.7 12.74 C 1.07 12.38 2.9 11.53 3.92 10.16 C 4.31 11.45 4.51 12.81 4.51 14.2 C 4.51 16.85 2.36 19 -0.29 19 Z' fill='{$theme["fire"]}' stroke-opacity='0'/>
@@ -494,21 +494,21 @@ function generateCard(array $stats, array $params = null): string
 
             </g>
             <g style='isolation: isolate'>
-                <!-- Longest Streak Big Number -->
+                <!-- Longest Streak big number -->
                 <g transform='translate({$thirdColumnOffset},48)'>
                     <text x='0' y='32' stroke-width='0' text-anchor='middle' fill='{$theme["sideNums"]}' stroke='none' font-family='\"Segoe UI\", Ubuntu, sans-serif' font-weight='700' font-size='28px' font-style='normal' style='opacity: 0; animation: fadein 0.5s linear forwards 1.2s'>
                         {$longestStreak}
                     </text>
                 </g>
 
-                <!-- Longest Streak Label -->
+                <!-- Longest Streak label -->
                 <g transform='translate({$thirdColumnOffset},84)'>
                     <text x='0' y='32' stroke-width='0' text-anchor='middle' fill='{$theme["sideLabels"]}' stroke='none' font-family='\"Segoe UI\", Ubuntu, sans-serif' font-weight='400' font-size='14px' font-style='normal' style='opacity: 0; animation: fadein 0.5s linear forwards 1.3s'>
                         {$longestStreakText}
                     </text>
                 </g>
 
-                <!-- Longest Streak Range -->
+                <!-- Longest Streak range -->
                 <g transform='translate({$thirdColumnOffset},114)'>
                     <text x='0' y='32' stroke-width='0' text-anchor='middle' fill='{$theme["dates"]}' stroke='none' font-family='\"Segoe UI\", Ubuntu, sans-serif' font-weight='400' font-size='12px' font-style='normal' style='opacity: 0; animation: fadein 0.5s linear forwards 1.4s'>
                         {$longestStreakRange}
@@ -559,14 +559,14 @@ function generateErrorCard(string $message, array $params = null): string
                 <rect stroke='{$theme["border"]}' fill='{$theme["background"]}' rx='{$borderRadius}' x='0.5' y='0.5' width='{$rectWidth}' height='194'/>
             </g>
             <g style='isolation: isolate'>
-                <!-- Error Label -->
+                <!-- Error lable -->
                 <g transform='translate({$centerOffset},108)'>
                     <text x='0' y='50' dy='0.25em' stroke-width='0' text-anchor='middle' fill='{$theme["sideLabels"]}' stroke='none' font-family='\"Segoe UI\", Ubuntu, sans-serif' font-weight='400' font-size='14px' font-style='normal'>
                         {$message}
                     </text>
                 </g>
 
-                <!-- mask for background behind face -->
+                <!-- Mask for background behind face -->
                 <defs>
                     <mask id='cut-off-area'>
                         <rect x='0' y='0' width='500' height='500' fill='white' />

--- a/tests/RenderTest.php
+++ b/tests/RenderTest.php
@@ -231,4 +231,22 @@ final class RenderTest extends TestCase
         $this->assertStringContainsString("<g transform='translate(300,", $render);
         $this->assertStringContainsString("<g transform='translate(500,", $render);
     }
+
+    /**
+     * Test first and third columns swapped when direction is rtl
+     */
+    public function testFirstAndThirdColumnsSwappedWhenDirectionIsRtl(): void
+    {
+        $this->testParams["locale"] = "he";
+        $render = generateOutput($this->testStats, $this->testParams)["body"];
+        $renderCollapsedSpaces = preg_replace("/(\s)\s*/", '$1', $render);
+        $this->assertStringContainsString(
+            "<!-- Total Contributions big number -->\n<g transform='translate(412.5,48)'>",
+            $renderCollapsedSpaces
+        );
+        $this->assertStringContainsString(
+            "<!-- Longest Streak big number -->\n<g transform='translate(82.5,48)'>",
+            $renderCollapsedSpaces
+        );
+    }
 }

--- a/tests/expected/test_card.svg
+++ b/tests/expected/test_card.svg
@@ -30,21 +30,21 @@
                 <line x1='165' y1='28' x2='165' y2='170' vector-effect='non-scaling-stroke' stroke-width='1' stroke='#222222' stroke-linejoin='miter' stroke-linecap='square' stroke-miterlimit='3'/>
             </g>
             <g style='isolation: isolate'>
-                <!-- Total Contributions Big Number -->
+                <!-- Total Contributions big number -->
                 <g transform='translate(82.5,48)'>
                     <text x='0' y='32' stroke-width='0' text-anchor='middle' fill='#666666' stroke='none' font-family='"Segoe UI", Ubuntu, sans-serif' font-weight='700' font-size='28px' font-style='normal' style='opacity: 0; animation: fadein 0.5s linear forwards 0.6s'>
                         2,048
                     </text>
                 </g>
 
-                <!-- Total Contributions Label -->
+                <!-- Total Contributions label -->
                 <g transform='translate(82.5,84)'>
                     <text x='0' y='32' stroke-width='0' text-anchor='middle' fill='#888888' stroke='none' font-family='"Segoe UI", Ubuntu, sans-serif' font-weight='400' font-size='14px' font-style='normal' style='opacity: 0; animation: fadein 0.5s linear forwards 0.7s'>
                         Total Contributions
                     </text>
                 </g>
 
-                <!-- total contributions range -->
+                <!-- Total Contributions range -->
                 <g transform='translate(82.5,114)'>
                     <text x='0' y='32' stroke-width='0' text-anchor='middle' fill='#999999' stroke='none' font-family='"Segoe UI", Ubuntu, sans-serif' font-weight='400' font-size='12px' font-style='normal' style='opacity: 0; animation: fadein 0.5s linear forwards 0.8s'>
                         Aug 10, 2016 - Present
@@ -52,32 +52,32 @@
                 </g>
             </g>
             <g style='isolation: isolate'>
-                <!-- Current Streak Big Number -->
+                <!-- Current Streak big number -->
                 <g transform='translate(247.5,48)'>
                     <text x='0' y='32' stroke-width='0' text-anchor='middle' fill='#555555' stroke='none' font-family='"Segoe UI", Ubuntu, sans-serif' font-weight='700' font-size='28px' font-style='normal' style='animation: currstreak 0.6s linear forwards'>
                         16
                     </text>
                 </g>
 
-                <!-- Current Streak Label -->
+                <!-- Current Streak label -->
                 <g transform='translate(247.5,108)'>
                     <text x='0' y='32' stroke-width='0' text-anchor='middle' fill='#777777' stroke='none' font-family='"Segoe UI", Ubuntu, sans-serif' font-weight='700' font-size='14px' font-style='normal' style='opacity: 0; animation: fadein 0.5s linear forwards 0.9s'>
                         Current Streak
                     </text>
                 </g>
 
-                <!-- Current Streak Range -->
+                <!-- Current Streak range -->
                 <g transform='translate(247.5,145)'>
                     <text x='0' y='21' stroke-width='0' text-anchor='middle' fill='#999999' stroke='none' font-family='"Segoe UI", Ubuntu, sans-serif' font-weight='400' font-size='12px' font-style='normal' style='opacity: 0; animation: fadein 0.5s linear forwards 0.9s'>
                         Mar 28, 2019 - Apr 12, 2019
                     </text>
                 </g>
 
-                <!-- ring around number -->
+                <!-- Ring around number -->
                 <g mask='url(#mask_out_ring_behind_fire)'>
                     <circle cx='247.5' cy='71' r='40' fill='none' stroke='#333333' stroke-width='5' style='opacity: 0; animation: fadein 0.5s linear forwards 0.4s'></circle>
                 </g>
-                <!-- fire icon -->
+                <!-- Fire icon -->
                 <g transform='translate(247.5, 19.5)' stroke-opacity='0' style='opacity: 0; animation: fadein 0.5s linear forwards 0.6s'>
                     <path d='M -12 -0.5 L 15 -0.5 L 15 23.5 L -12 23.5 L -12 -0.5 Z' fill='none'/>
                     <path d='M 1.5 0.67 C 1.5 0.67 2.24 3.32 2.24 5.47 C 2.24 7.53 0.89 9.2 -1.17 9.2 C -3.23 9.2 -4.79 7.53 -4.79 5.47 L -4.76 5.11 C -6.78 7.51 -8 10.62 -8 13.99 C -8 18.41 -4.42 22 0 22 C 4.42 22 8 18.41 8 13.99 C 8 8.6 5.41 3.79 1.5 0.67 Z M -0.29 19 C -2.07 19 -3.51 17.6 -3.51 15.86 C -3.51 14.24 -2.46 13.1 -0.7 12.74 C 1.07 12.38 2.9 11.53 3.92 10.16 C 4.31 11.45 4.51 12.81 4.51 14.2 C 4.51 16.85 2.36 19 -0.29 19 Z' fill='#444444' stroke-opacity='0'/>
@@ -85,21 +85,21 @@
 
             </g>
             <g style='isolation: isolate'>
-                <!-- Longest Streak Big Number -->
+                <!-- Longest Streak big number -->
                 <g transform='translate(412.5,48)'>
                     <text x='0' y='32' stroke-width='0' text-anchor='middle' fill='#666666' stroke='none' font-family='"Segoe UI", Ubuntu, sans-serif' font-weight='700' font-size='28px' font-style='normal' style='opacity: 0; animation: fadein 0.5s linear forwards 1.2s'>
                         86
                     </text>
                 </g>
 
-                <!-- Longest Streak Label -->
+                <!-- Longest Streak label -->
                 <g transform='translate(412.5,84)'>
                     <text x='0' y='32' stroke-width='0' text-anchor='middle' fill='#888888' stroke='none' font-family='"Segoe UI", Ubuntu, sans-serif' font-weight='400' font-size='14px' font-style='normal' style='opacity: 0; animation: fadein 0.5s linear forwards 1.3s'>
                         Longest Streak
                     </text>
                 </g>
 
-                <!-- Longest Streak Range -->
+                <!-- Longest Streak range -->
                 <g transform='translate(412.5,114)'>
                     <text x='0' y='32' stroke-width='0' text-anchor='middle' fill='#999999' stroke='none' font-family='"Segoe UI", Ubuntu, sans-serif' font-weight='400' font-size='12px' font-style='normal' style='opacity: 0; animation: fadein 0.5s linear forwards 1.4s'>
                         Dec 19, 2016 - Mar 14, 2016

--- a/tests/expected/test_error_card.svg
+++ b/tests/expected/test_error_card.svg
@@ -14,14 +14,14 @@
                 <rect stroke='#111111' fill='#000000' rx='4.5' x='0.5' y='0.5' width='494' height='194'/>
             </g>
             <g style='isolation: isolate'>
-                <!-- Error Label -->
+                <!-- Error lable -->
                 <g transform='translate(247.5,108)'>
                     <text x='0' y='50' dy='0.25em' stroke-width='0' text-anchor='middle' fill='#888888' stroke='none' font-family='"Segoe UI", Ubuntu, sans-serif' font-weight='400' font-size='14px' font-style='normal'>
                         An unknown error occurred
                     </text>
                 </g>
 
-                <!-- mask for background behind face -->
+                <!-- Mask for background behind face -->
                 <defs>
                     <mask id='cut-off-area'>
                         <rect x='0' y='0' width='500' height='500' fill='white' />


### PR DESCRIPTION
## Description

Swapped locations of total contributions and longest streak for right-to-left languages.

Naturally, when a language is read right to left, the order of elements are reversed.

### Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (added a non-breaking change which fixes an issue)
- [x] New feature (added a non-breaking change which adds functionality)
- [ ] Updated documentation (updated the readme, templates, or other repo files)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

<!--
If you have changed a feature of the stats cards, please describe the tests you made to verify your changes.
Changes strictly related to documentation can skip this section.
-->

- [x] Tested locally with a valid username
- [x] Tested locally with an invalid username
- [x] Ran tests with `composer test`
- [x] Added or updated test cases to test new features

## Checklist:

- [x] I have checked to make sure no other [pull requests](https://github.com/DenverCoder1/github-readme-streak-stats/pulls?q=is%3Apr+sort%3Aupdated-desc+) are open for this issue
- [x] The code is properly formatted and is consistent with the existing code style
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Screenshots

<!-- If you have updated the design or appearance, please include a screenshot of your changes. -->

![image](https://user-images.githubusercontent.com/20955511/232608486-8516bb7d-5c77-428d-a266-e6911eb5f69f.png)


![image](https://user-images.githubusercontent.com/20955511/232608447-34fc387a-2d0a-411f-a6bd-42c68bf57c13.png)
