### PR TITLE
fix: Demo Site link in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 
 Here you can customize your Streak Stats card with a live preview.
 
-<http://streak-stats.demolab.com>
+<https://streak-stats.demolab.com>
 
 [![Demo Site](https://user-images.githubusercontent.com/20955511/114579753-dbac8780-9c86-11eb-97dd-207039f67d20.gif "Demo Site")](http://streak-stats.demolab.com/demo/)
 


### PR DESCRIPTION
## Description

Change Demo Site link ("http://" to  "https://")  in the Readme file

Fixes  #518

### Type of change
- [ ] Updated documentation (updated the readme, templates, or other repo files)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ ] I have checked to make sure no other [pull requests](https://github.com/DenverCoder1/github-readme-streak-stats/pulls?q=is%3Apr+sort%3Aupdated-desc+) are open for this issue
- [ ] The code is properly formatted and is consistent with the existing code style
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

