### PR TITLE
feat: Update Brazilian Portuguese translations

### DIFF
--- a/src/translations.php
+++ b/src/translations.php
@@ -246,7 +246,7 @@ return [
         "Present" => "اوس",
     ],
     "pt_BR" => [
-        "Total Contributions" => "Total de Contribuições",
+        "Total Contributions" => "Contribuições Totais",
         "Current Streak" => "Sequência Atual",
         "Longest Streak" => "Maior Sequência",
         "Week Streak" => "Sequência Semanal",

--- a/src/translations.php
+++ b/src/translations.php
@@ -252,6 +252,7 @@ return [
         "Week Streak" => "Sequência Semanal",
         "Longest Week Streak" => "Maior Sequência Semanal",
         "Present" => "Presente",
+        "Excluding" => "Exceto",
     ],
     "ru" => [
         "Total Contributions" => "Общий вклад",


### PR DESCRIPTION
## Description
- Shortened and more accurate brazilian translation from `Total Contributions`;
- Excluding translation - Was translated as `Except`

## Why?
***Total de Contribuições*** is correct but i think ***Contribuições Totais*** is way better because it removes preposition ***de***.

**Excluding** in this context is with meaning of **Except** in pt-BR. So the accurate way to translate **Excluding** is ***Exceto***.

### Type of change

- [x] Updated documentation (updated the readme, templates, or other repo files)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

- https://translate.google.com.br/?hl=pt-BR&sl=en&tl=pt&text=total%20contributions&op=translate
- https://translate.google.com.br/?hl=pt-BR&sl=en&tl=pt&text=except&op=translate

## Checklist:

- [x] I have checked to make sure no other [pull requests](https://github.com/DenverCoder1/github-readme-streak-stats/pulls?q=is%3Apr+sort%3Aupdated-desc+) are open for this issue
- [x] The code is properly formatted and is consistent with the existing code style
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
