### PR TITLE
Changed wrong and/or confusing danish translations

### DIFF
--- a/src/translations.php
+++ b/src/translations.php
@@ -84,12 +84,12 @@ return [
         "Excluding" => "Excloent",
     ],
     "da" => [
-        "Total Contributions" => "Totalt Antal Bidrag",
-        "Current Streak" => "Nuværende i Træk",
-        "Longest Streak" => "Længst i Træk",
-        "Week Streak" => "Uger i Træk",
-        "Longest Week Streak" => "Mest Uger i Træk",
-        "Present" => "I Dag",
+        "Total Contributions" => "Samlet antal bidrag",
+        "Current Streak" => "Bidrag i træk",
+        "Longest Streak" => "Flest bidrag i træk",
+        "Week Streak" => "Ugentlige bidrag i træk",
+        "Longest Week Streak" => "Flest ugentlige bidrag i træk",
+        "Present" => "Nuværende",
     ],
     "de" => [
         "Total Contributions" => "Gesamte Beiträge",


### PR DESCRIPTION
## Description
Changed multiple danish translations which were incorrect, misleading or directly translated from english (too "Google translatey").

Fixes # 236

### Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (added a non-breaking change which fixes an issue)

## How Has This Been Tested?
Untested. It's a simple string change.

## Checklist:

- [x] I have checked to make sure no other [pull requests](https://github.com/DenverCoder1/github-readme-streak-stats/pulls?q=is%3Apr+sort%3Aupdated-desc+) are open for this issue
- [x] The code is properly formatted and is consistent with the existing code style
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
