### PR TITLE
feat: Support word order change, comma separation, Japanese for Excluding

### DIFF
--- a/scripts/translation-progress.php
+++ b/scripts/translation-progress.php
@@ -17,7 +17,7 @@ function getProgress(array $translations): array
         "Week Streak",
         "Longest Week Streak",
         "Present",
-        "Excluding",
+        "Excluding {days}",
     ];
 
     $translations_file = file(__DIR__ . "/../src/translations.php");

--- a/src/card.php
+++ b/src/card.php
@@ -61,16 +61,17 @@ function formatDate(string $dateString, string|null $format, string $locale): st
  *
  * @param array<string> $days List of days to translate
  * @param string $locale Locale code
- * @param string $skeleton Skeleton for the date pattern (eg. "EEE" for short day names, "EEEE" for long day names)
+ * @param "long"|"short" $dayOfWeekFormat Format for the day of the week (long or short)
  *
  * @return array<string> Translated days
  */
-function translateDays(array $days, string $locale, string $skeleton): array
+function translateDays(array $days, string $locale, string $dayOfWeekFormat): array
 {
     if ($locale === "en") {
         return $days;
     }
     $patternGenerator = new IntlDatePatternGenerator($locale);
+    $skeleton = $dayOfWeekFormat === "long" ? "EEEE" : "EEE";
     $pattern = $patternGenerator->getBestPattern($skeleton);
     $dateFormatter = new IntlDateFormatter(
         $locale,
@@ -414,8 +415,8 @@ function generateCard(array $stats, array $params = null): string
     $excludedDays = "";
     if (!empty($stats["excludedDays"])) {
         $separator = $localeTranslations["comma_separator"] ?? ", ";
-        $skeleton = $localeTranslations["day_of_week_format"] ?? "EEE";
-        $daysCommaSeparated = implode($separator, translateDays($stats["excludedDays"], $localeCode, $skeleton));
+        $dayOfWeekFormat = $localeTranslations["day_of_week_format"] ?? "EEE";
+        $daysCommaSeparated = implode($separator, translateDays($stats["excludedDays"], $localeCode, $dayOfWeekFormat));
         $offset = $direction === "rtl" ? $cardWidth - 5 : 5;
         $excludingDaysText = str_replace("{days}", $daysCommaSeparated, $localeTranslations["Excluding {days}"]);
         $excludedDays = "<g style='isolation: isolate'>

--- a/src/card.php
+++ b/src/card.php
@@ -61,16 +61,17 @@ function formatDate(string $dateString, string|null $format, string $locale): st
  *
  * @param array<string> $days List of days to translate
  * @param string $locale Locale code
+ * @param string $skeleton Skeleton for the date pattern (eg. "EEE" for short day names, "EEEE" for long day names)
  *
  * @return array<string> Translated days
  */
-function translateDays(array $days, string $locale): array
+function translateDays(array $days, string $locale, string $skeleton): array
 {
     if ($locale === "en") {
         return $days;
     }
     $patternGenerator = new IntlDatePatternGenerator($locale);
-    $pattern = $patternGenerator->getBestPattern("EEE");
+    $pattern = $patternGenerator->getBestPattern($skeleton);
     $dateFormatter = new IntlDateFormatter(
         $locale,
         IntlDateFormatter::NONE,
@@ -412,13 +413,16 @@ function generateCard(array $stats, array $params = null): string
     // if days are excluded, add a note to the corner
     $excludedDays = "";
     if (!empty($stats["excludedDays"])) {
-        $daysCommaSeparated = implode(", ", translateDays($stats["excludedDays"], $localeCode));
+        $separator = $localeTranslations["comma_separator"] ?? ", ";
+        $skeleton = $localeTranslations["day_of_week_format"] ?? "EEE";
+        $daysCommaSeparated = implode($separator, translateDays($stats["excludedDays"], $localeCode, $skeleton));
         $offset = $direction === "rtl" ? $cardWidth - 5 : 5;
+        $excludingDaysText = str_replace("{days}", $daysCommaSeparated, $localeTranslations["Excluding {days}"]);
         $excludedDays = "<g style='isolation: isolate'>
                 <!-- Excluded Days -->
                 <g transform='translate({$offset},187)'>
                     <text stroke-width='0' text-anchor='right' fill='{$theme["excludeDaysLabel"]}' stroke='none' font-family='\"Segoe UI\", Ubuntu, sans-serif' font-weight='400' font-size='10px' font-style='normal' style='opacity: 0; animation: fadein 0.5s linear forwards 0.9s'>
-                        * {$localeTranslations["Excluding"]} {$daysCommaSeparated}
+                        * {$excludingDaysText}
                     </text>
                 </g>
             </g>";

--- a/src/card.php
+++ b/src/card.php
@@ -61,18 +61,16 @@ function formatDate(string $dateString, string|null $format, string $locale): st
  *
  * @param array<string> $days List of days to translate
  * @param string $locale Locale code
- * @param "long"|"short" $dayOfWeekFormat Format for the day of the week (long or short)
  *
  * @return array<string> Translated days
  */
-function translateDays(array $days, string $locale, string $dayOfWeekFormat): array
+function translateDays(array $days, string $locale): array
 {
     if ($locale === "en") {
         return $days;
     }
     $patternGenerator = new IntlDatePatternGenerator($locale);
-    $skeleton = $dayOfWeekFormat === "long" ? "EEEE" : "EEE";
-    $pattern = $patternGenerator->getBestPattern($skeleton);
+    $pattern = $patternGenerator->getBestPattern("EEE");
     $dateFormatter = new IntlDateFormatter(
         $locale,
         IntlDateFormatter::NONE,
@@ -97,8 +95,7 @@ function translateDays(array $days, string $locale, string $dayOfWeekFormat): ar
 function getExcludingDaysText($excludedDays, $localeTranslations, $localeCode)
 {
     $separator = $localeTranslations["comma_separator"] ?? ", ";
-    $dayOfWeekFormat = $localeTranslations["day_of_week_format"] ?? "EEE";
-    $daysCommaSeparated = implode($separator, translateDays($excludedDays, $localeCode, $dayOfWeekFormat));
+    $daysCommaSeparated = implode($separator, translateDays($excludedDays, $localeCode));
     return str_replace("{days}", $daysCommaSeparated, $localeTranslations["Excluding {days}"]);
 }
 

--- a/src/card.php
+++ b/src/card.php
@@ -87,6 +87,22 @@ function translateDays(array $days, string $locale, string $dayOfWeekFormat): ar
 }
 
 /**
+ * Get the excluding days text
+ *
+ * @param array<string> $excludedDays List of excluded days
+ * @param array<string,string> $localeTranslations Translations for the locale
+ * @param string $localeCode Locale code
+ * @return string Excluding days text
+ */
+function getExcludingDaysText($excludedDays, $localeTranslations, $localeCode)
+{
+    $separator = $localeTranslations["comma_separator"] ?? ", ";
+    $dayOfWeekFormat = $localeTranslations["day_of_week_format"] ?? "EEE";
+    $daysCommaSeparated = implode($separator, translateDays($excludedDays, $localeCode, $dayOfWeekFormat));
+    return str_replace("{days}", $daysCommaSeparated, $localeTranslations["Excluding {days}"]);
+}
+
+/**
  * Normalize a theme name
  *
  * @param string $theme Theme name
@@ -414,11 +430,8 @@ function generateCard(array $stats, array $params = null): string
     // if days are excluded, add a note to the corner
     $excludedDays = "";
     if (!empty($stats["excludedDays"])) {
-        $separator = $localeTranslations["comma_separator"] ?? ", ";
-        $dayOfWeekFormat = $localeTranslations["day_of_week_format"] ?? "EEE";
-        $daysCommaSeparated = implode($separator, translateDays($stats["excludedDays"], $localeCode, $dayOfWeekFormat));
         $offset = $direction === "rtl" ? $cardWidth - 5 : 5;
-        $excludingDaysText = str_replace("{days}", $daysCommaSeparated, $localeTranslations["Excluding {days}"]);
+        $excludingDaysText = getExcludingDaysText($stats["excludedDays"], $localeTranslations, $localeCode);
         $excludedDays = "<g style='isolation: isolate'>
                 <!-- Excluded Days -->
                 <g transform='translate({$offset},187)'>

--- a/src/translations.php
+++ b/src/translations.php
@@ -124,7 +124,6 @@ return [
         "Longest Week Streak" => "Μεγαλύτερη Εβδομαδιαία Σειρά",
         "Present" => "Σήμερα",
         "Excluding {days}" => "Εξαιρούνται {days}",
-        "comma_separator" => " ",
     ],
     "es" => [
         "Total Contributions" => "Contribuciones Totales",

--- a/src/translations.php
+++ b/src/translations.php
@@ -29,7 +29,7 @@
  * Day of Week Format
  * ------------------
  * The default day of week format is "EEE" which is usually a short abbreviation of the day of week (e.g. "Mon", "Tue", etc.).
- * To force the full day of week to be displayed for a locale, add `"day_of_week_format" => "EEEE"` to the locale array.
+ * To force the full day of week to be displayed for a locale (e.g. "Monday", "Tuesday", etc.), add `"day_of_week_format" => "long"` to the locale array.
  *
  * Aliases
  * -------
@@ -240,7 +240,7 @@ return [
         "Present" => "今",
         "Excluding {days}" => "{days}を除く",
         "comma_separator" => "、",
-        "day_of_week_format" => "EEEE",
+        "day_of_week_format" => "long",
     ],
     "kn" => [
         "Total Contributions" => "ಒಟ್ಟು ಕೊಡುಗೆ",

--- a/src/translations.php
+++ b/src/translations.php
@@ -239,8 +239,7 @@ return [
         "Longest Week Streak" => "最長の週間ストリーク",
         "Present" => "今",
         "Excluding {days}" => "{days}を除く",
-        "comma_separator" => "、",
-        "day_of_week_format" => "long",
+        "comma_separator" => "・",
     ],
     "kn" => [
         "Total Contributions" => "ಒಟ್ಟು ಕೊಡುಗೆ",

--- a/src/translations.php
+++ b/src/translations.php
@@ -26,11 +26,6 @@
  * ---------------
  * To change the comma separator in the enumeration of excluded days, add `"comma_separator" => ", "` to the locale array with the desired separator as the value.
  *
- * Day of Week Format
- * ------------------
- * The default day of week format is "EEE" which is usually a short abbreviation of the day of week (e.g. "Mon", "Tue", etc.).
- * To force the full day of week to be displayed for a locale (e.g. "Monday", "Tuesday", etc.), add `"day_of_week_format" => "long"` to the locale array.
- *
  * Aliases
  * -------
  * To add an alias for a locale, add the alias as a key to the locale array with the locale it should redirect to as the value.

--- a/src/translations.php
+++ b/src/translations.php
@@ -458,5 +458,6 @@ return [
         "Longest Week Streak" => "最常周連續貢獻",
         "Present" => "至今",
         "Excluding {days}" => "除外 {days}",
+        "comma_separator" => "、",
     ],
 ];

--- a/src/translations.php
+++ b/src/translations.php
@@ -22,6 +22,15 @@
  * ------------------------------
  * To enable right-to-left language support, add `"rtl" => true` to the locale array (see "he" for an example).
  *
+ * Comma Separator
+ * ---------------
+ * To change the comma separator in the enumeration of excluded days, add `"comma_separator" => ", "` to the locale array with the desired separator as the value.
+ *
+ * Day of Week Format
+ * ------------------
+ * The default day of week format is "EEE" which is usually a short abbreviation of the day of week (e.g. "Mon", "Tue", etc.).
+ * To force the full day of week to be displayed for a locale, add `"day_of_week_format" => "EEEE"` to the locale array.
+ *
  * Aliases
  * -------
  * To add an alias for a locale, add the alias as a key to the locale array with the locale it should redirect to as the value.
@@ -37,7 +46,7 @@ return [
         "Week Streak" => "Week Streak",
         "Longest Week Streak" => "Longest Week Streak",
         "Present" => "Present",
-        "Excluding" => "Excluding",
+        "Excluding {days}" => "Excluding {days}",
     ],
     // Locales below are sorted alphabetically
     "am" => [
@@ -47,7 +56,7 @@ return [
         "Week Streak" => "የሳምንት ድግግሞሽ",
         "Longest Week Streak" => "በጣም ረጅሙ የሳምንት ድግግሞሽ",
         "Present" => "ያሁኑ",
-        "Excluding" => "ሳይጨምር",
+        "Excluding {days}" => "ሳይጨምር {days}",
     ],
     "ar" => [
         "rtl" => true,
@@ -57,7 +66,8 @@ return [
         "Week Streak" => "السلسلة المتتالية الأُسبوعية",
         "Longest Week Streak" => "أُطول سلسلة متتالية أُسبوعية",
         "Present" => "الحاضر",
-        "Excluding" => "باستثناء",
+        "Excluding {days}" => "باستثناء {days}",
+        "comma_separator" => "، ",
     ],
     "bg" => [
         "Total Contributions" => "Общ принос",
@@ -82,7 +92,7 @@ return [
         "Week Streak" => "Ratxa setmanal",
         "Longest Week Streak" => "Ratxa setmanal més llarga",
         "Present" => "Actual",
-        "Excluding" => "Excloent",
+        "Excluding {days}" => "Excloent {days}",
     ],
     "ceb" => [
         "Total Contributions" => "Kinatibuk-ang Kontribusyon",
@@ -91,7 +101,7 @@ return [
         "Week Streak" => "Sinemana nga Streak",
         "Longest Week Streak" => "Pinakataas nga Semana nga Streak",
         "Present" => "Karon",
-        "Excluding" => "Wala'y Labot",
+        "Excluding {days}" => "Wala'y Labot {days}",
     ],
     "da" => [
         "Total Contributions" => "Samlet antal bidrag",
@@ -100,7 +110,7 @@ return [
         "Week Streak" => "Ugentlige bidrag i træk",
         "Longest Week Streak" => "Flest ugentlige bidrag i træk",
         "Present" => "Nuværende",
-        "Excluding" => "Ekskluderer",
+        "Excluding {days}" => "Ekskluderer {days}",
     ],
     "de" => [
         "Total Contributions" => "Gesamte Beiträge",
@@ -109,7 +119,7 @@ return [
         "Week Streak" => "Wochenserie",
         "Longest Week Streak" => "Längste Wochenserie",
         "Present" => "Heute",
-        "Excluding" => "Ausgenommen",
+        "Excluding {days}" => "Ausgenommen {days}",
     ],
     "el" => [
         "Total Contributions" => "Συνολικές Συνεισφορές",
@@ -118,7 +128,8 @@ return [
         "Week Streak" => "Εβδομαδιαία Σειρά",
         "Longest Week Streak" => "Μεγαλύτερη Εβδομαδιαία Σειρά",
         "Present" => "Σήμερα",
-        "Excluding" => "Εξαιρούνται",
+        "Excluding {days}" => "Εξαιρούνται {days}",
+        "comma_separator" => " ",
     ],
     "es" => [
         "Total Contributions" => "Contribuciones Totales",
@@ -127,7 +138,7 @@ return [
         "Week Streak" => "Racha Semanal",
         "Longest Week Streak" => "Racha Semanal Más Larga",
         "Present" => "Presente",
-        "Excluding" => "Excluyendo",
+        "Excluding {days}" => "Excluyendo {days}",
     ],
     "fa" => [
         "rtl" => true,
@@ -137,6 +148,7 @@ return [
         "Week Streak" => "پی‌رفت هفته",
         "Longest Week Streak" => "طولانی ترین پی‌رفت هفته",
         "Present" => "اکنون",
+        "comma_separator" => "، ",
     ],
     "fil" => [
         "Total Contributions" => "Kabuuang Kontribusyon",
@@ -145,7 +157,7 @@ return [
         "Week Streak" => "Linggong Streak",
         "Longest Week Streak" => "Pinakamahabang Linggong Streak",
         "Present" => "Kasalukuyan",
-        "Excluding" => "Hindi Kasama",
+        "Excluding {days}" => "Hindi Kasama {days}",
     ],
     "fr" => [
         "Total Contributions" => "Contributions totales",
@@ -154,7 +166,7 @@ return [
         "Week Streak" => "Séquence de la semaine",
         "Longest Week Streak" => "Plus longue séquence hebdomadaire",
         "Present" => "Aujourd'hui",
-        "Excluding" => "À l'exclusion de",
+        "Excluding {days}" => "À l'exclusion de {days}",
     ],
     "he" => [
         "rtl" => true,
@@ -164,7 +176,7 @@ return [
         "Week Streak" => "רצף שבועי",
         "Longest Week Streak" => "רצף שבועי הכי ארוך",
         "Present" => "היום",
-        "Excluding" => "לא כולל",
+        "Excluding {days}" => "לא כולל {days}",
     ],
     "hi" => [
         "Total Contributions" => "कुल योगदान",
@@ -173,7 +185,7 @@ return [
         "Week Streak" => "सप्ताहिक योगदान",
         "Longest Week Streak" => "दीर्घ साप्ताहिक योगदान",
         "Present" => "आज तक",
-        "Excluding" => "के सिवा",
+        "Excluding {days}" => "के सिवा {days}",
     ],
     "ht" => [
         "Total Contributions" => "kontribisyon total",
@@ -190,7 +202,7 @@ return [
         "Week Streak" => "Heti sorozat",
         "Longest Week Streak" => "Leghosszabb heti sorozat",
         "Present" => "Jelen",
-        "Excluding" => "Kivéve",
+        "Excluding {days}" => "Kivéve {days}",
     ],
     "hy" => [
         "Total Contributions" => "Ընդհանուր\nներդրումը",
@@ -207,7 +219,7 @@ return [
         "Week Streak" => "Aksi Mingguan",
         "Longest Week Streak" => "Aksi Mingguan Terpanjang",
         "Present" => "Sekarang",
-        "Excluding" => "Tidak termasuk",
+        "Excluding {days}" => "Tidak termasuk {days}",
     ],
     "it" => [
         "Total Contributions" => "Contributi Totali",
@@ -216,7 +228,7 @@ return [
         "Week Streak" => "Serie Settimanale",
         "Longest Week Streak" => "Serie Settimanale più Lunga",
         "Present" => "Presente",
-        "Excluding" => "Escludendo",
+        "Excluding {days}" => "Escludendo {days}",
     ],
     "ja" => [
         "date_format" => "[Y.]n.j",
@@ -226,6 +238,9 @@ return [
         "Week Streak" => "週間ストリーク",
         "Longest Week Streak" => "最長の週間ストリーク",
         "Present" => "今",
+        "Excluding {days}" => "{days}を除く",
+        "comma_separator" => "、",
+        "day_of_week_format" => "EEEE",
     ],
     "kn" => [
         "Total Contributions" => "ಒಟ್ಟು ಕೊಡುಗೆ",
@@ -234,7 +249,7 @@ return [
         "Week Streak" => "ವಾರದ ಸ್ಟ್ರೀಕ್",
         "Longest Week Streak" => "ಅತ್ಯಧಿಕ ವಾರದ ಸ್ಟ್ರೀಕ್",
         "Present" => "ಪ್ರಸ್ತುತ",
-        "Excluding" => "ಹೊರತುಪಡಿಸಿ",
+        "Excluding {days}" => "ಹೊರತುಪಡಿಸಿ {days}",
     ],
     "ko" => [
         "Total Contributions" => "총 기여 수",
@@ -243,7 +258,7 @@ return [
         "Week Streak" => "주간 기여 수",
         "Longest Week Streak" => "최대 주간 기여 수",
         "Present" => "현재",
-        "Excluding" => "제외된 날",
+        "Excluding {days}" => "제외된 날 {days}",
     ],
     "mr" => [
         "Total Contributions" => "एकूण योगदान",
@@ -260,7 +275,7 @@ return [
         "Week Streak" => "Tindakan Setiap Minggu",
         "Longest Week Streak" => "Tindakan Setiap Minggu Terpanjang",
         "Present" => "Sekarang",
-        "Excluding" => "Mengecualikan",
+        "Excluding {days}" => "Mengecualikan {days}",
     ],
     "ne" => [
         "Total Contributions" => "कुल योगदान",
@@ -269,7 +284,7 @@ return [
         "Week Streak" => "सप्ताहिक योगदान",
         "Longest Week Streak" => "सबैभन्दा लामो साप्ताहिक योगदान",
         "Present" => "आज सम्म",
-        "Excluding" => "बाहेक",
+        "Excluding {days}" => "बाहेक {days}",
     ],
     "nl" => [
         "Total Contributions" => "Totale Bijdrage",
@@ -278,7 +293,7 @@ return [
         "Week Streak" => "Week Serie",
         "Longest Week Streak" => "Langste Week Serie",
         "Present" => "Vandaag",
-        "Excluding" => "Exclusief",
+        "Excluding {days}" => "Exclusief {days}",
     ],
     "pl" => [
         "Total Contributions" => "Suma Kontrybucji",
@@ -296,6 +311,7 @@ return [
         "Week Streak" => "د اونۍ پرمختګ",
         "Longest Week Streak" => "د اونۍ تر ټولو اوږد پرمختګ",
         "Present" => "اوس",
+        "comma_separator" => "، ",
     ],
     "pt_BR" => [
         "Total Contributions" => "Total de Contribuições",
@@ -304,7 +320,7 @@ return [
         "Week Streak" => "Sequência Semanal",
         "Longest Week Streak" => "Maior Sequência Semanal",
         "Present" => "Presente",
-        "Excluding" => "Exceto",
+        "Excluding {days}" => "Exceto {days}",
     ],
     "ru" => [
         "Total Contributions" => "Общий вклад",
@@ -313,7 +329,7 @@ return [
         "Week Streak" => "Текущая серия недель",
         "Longest Week Streak" => "Самая длинная серия недель",
         "Present" => "Сейчас",
-        "Excluding" => "Не включая",
+        "Excluding {days}" => "Не включая {days}",
     ],
     "rw" => [
         "Total Contributions" => "Imisanzu yose",
@@ -330,7 +346,7 @@ return [
         "Week Streak" => "निरन्तरसप्ताहाः",
         "Longest Week Streak" => "दीर्घतमाः निरन्तरसप्ताहाः",
         "Present" => "वर्तमान",
-        "Excluding" => "बहिष्करणम्",
+        "Excluding {days}" => "बहिष्करणम् {days}",
     ],
     "sr" => [
         "Total Contributions" => "Укупно додавања",
@@ -339,7 +355,7 @@ return [
         "Week Streak" => "Недељна серија",
         "Longest Week Streak" => "Најдужа недељена серија",
         "Present" => "Данас",
-        "Excluding" => "Искључујући",
+        "Excluding {days}" => "Искључујући {days}",
     ],
     "su" => [
         "Total Contributions" => "Total Kontribusi",
@@ -348,7 +364,7 @@ return [
         "Week Streak" => "Aksi Unggal Minggon",
         "Longest Week Streak" => "Aksi Unggal Minggon Pangpanjangna",
         "Present" => "Ayeuna",
-        "Excluding" => "Teu Kaasup",
+        "Excluding {days}" => "Teu Kaasup {days}",
     ],
     "sv" => [
         "Total Contributions" => "Totalt antal uppladningar",
@@ -381,7 +397,7 @@ return [
         "Week Streak" => "สตรีคประจำสัปดาห์",
         "Longest Week Streak" => "สตรีคประจำสัปดาห์\nที่ยาวนานที่สุด",
         "Present" => "ปัจจุบัน",
-        "Excluding" => "ยกเว้น",
+        "Excluding {days}" => "ยกเว้น {days}",
     ],
     "tr" => [
         "Total Contributions" => "Toplam Katkı",
@@ -390,7 +406,7 @@ return [
         "Week Streak" => "Haftalık Seri",
         "Longest Week Streak" => "En Uzun Haftalık Seri",
         "Present" => "Şu an",
-        "Excluding" => "Hariç",
+        "Excluding {days}" => "Hariç {days}",
     ],
     "uk" => [
         "Total Contributions" => "Загальний вклад",
@@ -399,7 +415,7 @@ return [
         "Week Streak" => "Діяльність за тиждень",
         "Longest Week Streak" => "Найбільша к-сть тижнів",
         "Present" => "Наразі",
-        "Excluding" => "Виключаючи",
+        "Excluding {days}" => "Виключаючи {days}",
     ],
     "ur_PK" => [
         "rtl" => true,
@@ -409,7 +425,8 @@ return [
         "Week Streak" => "ہفتہ وار تسلسل",
         "Longest Week Streak" => "طویل ترین ہفتہ وار تسلسل",
         "Present" => "حاظر",
-        "Excluding" => "خارج",
+        "Excluding {days}" => "خارج {days}",
+        "comma_separator" => "، ",
     ],
     "vi" => [
         "Total Contributions" => "Tổng số đóng góp",
@@ -418,7 +435,7 @@ return [
         "Week Streak" => "Chuỗi tuần",
         "Longest Week Streak" => "Chuỗi tuần lớn nhất",
         "Present" => "Hiện tại",
-        "Excluding" => "Ngoại trừ",
+        "Excluding {days}" => "Ngoại trừ {days}",
     ],
     "yo" => [
         "Total Contributions" => "Lapapọ ilowosi",
@@ -427,7 +444,7 @@ return [
         "Week Streak" => "ṣiṣan ọsẹ",
         "Longest Week Streak" => "gunjulo ọsẹ ṣiṣan",
         "Present" => "lọwọlọwọ",
-        "Excluding" => "Yato si",
+        "Excluding {days}" => "Yato si {days}",
     ],
     "zh" => "zh_Hans",
     "zh_Hans" => [
@@ -437,7 +454,8 @@ return [
         "Week Streak" => "周连续贡献",
         "Longest Week Streak" => "最长周连续贡献",
         "Present" => "至今",
-        "Excluding" => "除外",
+        "Excluding {days}" => "除外 {days}",
+        "comma_separator" => "、",
     ],
     "zh_Hant" => [
         "Total Contributions" => "合計貢獻",
@@ -446,6 +464,6 @@ return [
         "Week Streak" => "周連續貢獻",
         "Longest Week Streak" => "最常周連續貢獻",
         "Present" => "至今",
-        "Excluding" => "除外",
+        "Excluding {days}" => "除外 {days}",
     ],
 ];

--- a/tests/TranslationsTest.php
+++ b/tests/TranslationsTest.php
@@ -27,7 +27,6 @@ final class TranslationsTest extends TestCase
             "Present",
             "Excluding {days}",
             "comma_separator",
-            "day_of_week_format",
         ];
         foreach ($locales as $locale) {
             // if it is a string, assert that the alias exists in the translations file

--- a/tests/TranslationsTest.php
+++ b/tests/TranslationsTest.php
@@ -25,7 +25,9 @@ final class TranslationsTest extends TestCase
             "Week Streak",
             "Longest Week Streak",
             "Present",
-            "Excluding",
+            "Excluding {days}",
+            "comma_separator",
+            "day_of_week_format",
         ];
         foreach ($locales as $locale) {
             // if it is a string, assert that the alias exists in the translations file


### PR DESCRIPTION
## Description

* Adds support for putting the days before or within the translation for Excluding {days}
* Adds support for alternate comma separators ("، " for Arabic, Farsi, Urdu and "、" for Chinese, "・" for Japanese)
* ~~Adds support for overriding the day of week format to long names instead of short for specific locales~~
* Adds Japanese translation for Excluding {days}

### Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (added a non-breaking change which fixes an issue)
- [x] New feature (added a non-breaking change which adds functionality)
- [ ] Updated documentation (updated the readme, templates, or other repo files)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

<!--
If you have changed a feature of the stats cards, please describe the tests you made to verify your changes.
Changes strictly related to documentation can skip this section.
-->

- [x] Tested locally with a valid username
- [x] Tested locally with an invalid username
- [x] Ran tests with `composer test`
- [x] Added or updated test cases to test new features

## Checklist:

- [x] I have checked to make sure no other [pull requests](https://github.com/DenverCoder1/github-readme-streak-stats/pulls?q=is%3Apr+sort%3Aupdated-desc+) are open for this issue
- [x] The code is properly formatted and is consistent with the existing code style
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Screenshots

<!-- ![image](https://github.com/DenverCoder1/github-readme-streak-stats/assets/20955511/a9993b26-c501-49db-af13-494eb266eed9) -->

![image](https://github.com/DenverCoder1/github-readme-streak-stats/assets/20955511/b4a2c6bb-3277-4811-8be0-1dfff21e20e6)

