### PR TITLE
fix: Replace newline with space when converting SVG to PNG

### DIFF
--- a/src/card.php
+++ b/src/card.php
@@ -697,6 +697,9 @@ function convertSvgToPng(string $svg, int $cardWidth): string
     // remove style and animations
     $svg = removeAnimations($svg);
 
+    // replace newlines with spaces
+    $svg = str_replace("\n", " ", $svg);
+
     // escape svg for shell
     $svg = escapeshellarg($svg);
 


### PR DESCRIPTION
## Description

This makes the command all on a single line which may make PNG work better (#596) or at least make reading the logs easier

### Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (added a non-breaking change which fixes an issue)
- [ ] New feature (added a non-breaking change which adds functionality)
- [ ] Updated documentation (updated the readme, templates, or other repo files)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

<!--
If you have changed a feature of the stats cards, please describe the tests you made to verify your changes.
Changes strictly related to documentation can skip this section.
-->

- [x] Tested locally with a valid username
- [x] Tested locally with an invalid username
- [x] Ran tests with `composer test`
- [x] Added or updated test cases to test new features

## Checklist:

- [x] I have checked to make sure no other [pull requests](https://github.com/DenverCoder1/github-readme-streak-stats/pulls?q=is%3Apr+sort%3Aupdated-desc+) are open for this issue
- [x] The code is properly formatted and is consistent with the existing code style
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Screenshots

<!-- If you have updated the design or appearance, please include a screenshot of your changes. -->
