### PR TITLE
fix: Updated Korean for Excluding translation

### DIFF
--- a/src/translations.php
+++ b/src/translations.php
@@ -260,7 +260,7 @@ return [
         "Week Streak" => "주간 기여 수",
         "Longest Week Streak" => "최대 주간 기여 수",
         "Present" => "현재",
-        "Excluding {days}" => "제외된 날 {days}",
+        "Excluding {days}" => "{days} 제외된",
     ],
     "mr" => [
         "Total Contributions" => "एकूण योगदान",


### PR DESCRIPTION
## Description

Looking at the changes made in #604, it reminded me of the Korean translation for 'excluding.' Similar to Japanese, I modified the translation from the '제외된 날 {dates}' to '{dates} 제외된.' The use of '제외된' would make perfect sense when placed behind the day names. So, even without the word '날,' this sentence already makes sense, considering that before the significant change, we couldn't place '제외된' behind the day names.

### Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (added a non-breaking change which fixes an issue)
- [ ] New feature (added a non-breaking change which adds functionality)
- [ ] Updated documentation (updated the readme, templates, or other repo files)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

<!--
If you have changed a feature of the stats cards, please describe the tests you made to verify your changes.
Changes strictly related to documentation can skip this section.
-->

- [x] Tested locally with a valid username
- [x] Tested locally with an invalid username
- [x] Ran tests with `composer test`
- [x] Added or updated test cases to test new features

## Checklist:

- [x] I have checked to make sure no other [pull requests](https://github.com/DenverCoder1/github-readme-streak-stats/pulls?q=is%3Apr+sort%3Aupdated-desc+) are open for this issue
- [x] The code is properly formatted and is consistent with the existing code style
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Screenshots
_No screenshots_