### PR TITLE
docs(themes): Fix Catppuccin theme names

### DIFF
--- a/docs/themes.md
+++ b/docs/themes.md
@@ -126,7 +126,7 @@ Note: Theme names provided are case-insensitive and any use of underscores will 
 |       `ocean-gradient`        |      ![image](https://user-images.githubusercontent.com/20955511/233865264-3bb6c04d-05d2-47b1-857c-3f9a1277651f.png)      |
 |      `ambient-gradient`       |      ![image](https://user-images.githubusercontent.com/20955511/233865269-81583e73-c9b6-4e4b-9475-bc130de1bfdd.png)      |
 |      `catppuccin-latte`       |      ![image](https://user-images.githubusercontent.com/85760664/248204601-358a8a31-4ffc-4535-a617-840926ecd4f0.png)      |
-|     `catppuccin-frappe`       |      ![image](https://user-images.githubusercontent.com/85760664/248204858-daa7bd60-1e83-4b4e-8afc-65644055235e.png)      |
+|      `catppuccin-frappe`      |      ![image](https://user-images.githubusercontent.com/85760664/248204858-daa7bd60-1e83-4b4e-8afc-65644055235e.png)      |
 |    `catppuccin-macchiato`     |      ![image](https://user-images.githubusercontent.com/85760664/248205012-15d74ba2-746a-4efd-b2f5-bc2db87b7c10.png)      |
 |      `catppuccin-mocha`       |      ![image](https://user-images.githubusercontent.com/85760664/248204228-9f965d12-2013-48c9-b3a8-e9717b1c4e43.png)      |
 |         `burnt-neon`          |     ![image](https://user-images.githubusercontent.com/112064697/250343082-de641726-1200-4264-885a-154d539cfc3f.png)      |

--- a/docs/themes.md
+++ b/docs/themes.md
@@ -126,9 +126,9 @@ Note: Theme names provided are case-insensitive and any use of underscores will 
 |       `ocean-gradient`        |      ![image](https://user-images.githubusercontent.com/20955511/233865264-3bb6c04d-05d2-47b1-857c-3f9a1277651f.png)      |
 |      `ambient-gradient`       |      ![image](https://user-images.githubusercontent.com/20955511/233865269-81583e73-c9b6-4e4b-9475-bc130de1bfdd.png)      |
 |      `catppuccin-latte`       |      ![image](https://user-images.githubusercontent.com/85760664/248204601-358a8a31-4ffc-4535-a617-840926ecd4f0.png)      |
-|     `catppuccino-frappe`      |      ![image](https://user-images.githubusercontent.com/85760664/248204858-daa7bd60-1e83-4b4e-8afc-65644055235e.png)      |
-|    `catppuccino-macchiato`    |      ![image](https://user-images.githubusercontent.com/85760664/248205012-15d74ba2-746a-4efd-b2f5-bc2db87b7c10.png)      |
-|      `catppuccino-mocha`      |      ![image](https://user-images.githubusercontent.com/85760664/248204228-9f965d12-2013-48c9-b3a8-e9717b1c4e43.png)      |
+|     `catppuccin-frappe`       |      ![image](https://user-images.githubusercontent.com/85760664/248204858-daa7bd60-1e83-4b4e-8afc-65644055235e.png)      |
+|    `catppuccin-macchiato`     |      ![image](https://user-images.githubusercontent.com/85760664/248205012-15d74ba2-746a-4efd-b2f5-bc2db87b7c10.png)      |
+|      `catppuccin-mocha`       |      ![image](https://user-images.githubusercontent.com/85760664/248204228-9f965d12-2013-48c9-b3a8-e9717b1c4e43.png)      |
 |         `burnt-neon`          |     ![image](https://user-images.githubusercontent.com/112064697/250343082-de641726-1200-4264-885a-154d539cfc3f.png)      |
 |           `humoris`           |      ![image](https://user-images.githubusercontent.com/20955511/263020536-793bedbd-cca6-47e5-92dc-c7b38ab05bce.png)      |
 |         `shadow-red`          |      ![image](https://user-images.githubusercontent.com/86386385/263407052-345edfdf-b6ee-4b53-a4c4-7dcb4948f6dc.png)      |


### PR DESCRIPTION
## Description

Fixes typos on names in `themes.md` for the Catppuccin collection of themes.

I didn't open an issue since it was a pretty quick fix, but please let me know if I should open one :)

### Type of change

- [x] Updated documentation (updated the readme, templates, or other repo files)

## How Has This Been Tested?

N/A - documentation only :)

## Checklist:

- [x] I have checked to make sure no other [pull requests](https://github.com/DenverCoder1/github-readme-streak-stats/pulls?q=is%3Apr+sort%3Aupdated-desc+) are open for this issue
- [x] The code is properly formatted and is consistent with the existing code style
- [x] I have commented my code, particularly in hard-to-understand areas --> N/A
- [x] I have made corresponding changes to the documentation --> N/A
- [x] My changes generate no new warnings

## Screenshots

N/A - documentation only :)