### PR TITLE
feat: add Microsoft themes

### DIFF
--- a/docs/themes.md
+++ b/docs/themes.md
@@ -160,6 +160,7 @@ Note: Theme names provided are case-insensitive and any use of underscores will 
 |          `telegram`           |                 ![image](https://github.com/user-attachments/assets/59a5d9d5-8a2a-4916-aa46-a0a49a6f0372)                  |
 |            `taiga`            |                 ![image](https://github.com/user-attachments/assets/be4e961d-a13e-401a-90f8-f2b062a8c0f9)                  |
 |          `microsoft`          |                 ![image](https://github.com/user-attachments/assets/4c2cce9d-90b5-4e38-8422-656c5a78b4d9)                  |
+|       `microsoft-dark`        |                 ![image](https://github.com/user-attachments/assets/a5918d7d-f568-4012-b06f-d9cfacaece04)                  |
 
 ### Can't find the theme you like?
 

--- a/docs/themes.md
+++ b/docs/themes.md
@@ -159,6 +159,7 @@ Note: Theme names provided are case-insensitive and any use of underscores will 
 |       `dark-minimalist`       | ![image](https://github.com/DenverCoder1/github-readme-streak-stats/assets/77511070/11ba7899-1ad3-4c4b-880b-6f9e7c285f1b)  |
 |          `telegram`           |                 ![image](https://github.com/user-attachments/assets/59a5d9d5-8a2a-4916-aa46-a0a49a6f0372)                  |
 |            `taiga`            |                 ![image](https://github.com/user-attachments/assets/be4e961d-a13e-401a-90f8-f2b062a8c0f9)                  |
+|          `microsoft`          |                 ![image](https://github.com/user-attachments/assets/4c2cce9d-90b5-4e38-8422-656c5a78b4d9)                  |
 
 ### Can't find the theme you like?
 

--- a/src/themes.php
+++ b/src/themes.php
@@ -1965,4 +1965,17 @@ return [
         "dates" => "#1F8F92",
         "excludeDaysLabel" => "#1F8F92",
     ],
+    "microsoft" => [
+        "background" => "#FFFFFF",
+        "border" => "#737373",
+        "stroke" => "#737373",
+        "ring" => "#7FBA00",
+        "fire" => "#F25022",
+        "currStreakNum" => "#00A4EF",
+        "sideNums" => "#FFB900",
+        "currStreakLabel" => "#00A4EF",
+        "sideLabels" => "#FFB900",
+        "dates" => "#7FBA00",
+        "excludeDaysLabel" => "#7FBA00",
+    ],
 ];

--- a/src/themes.php
+++ b/src/themes.php
@@ -1978,4 +1978,17 @@ return [
         "dates" => "#7FBA00",
         "excludeDaysLabel" => "#7FBA00",
     ],
+    "microsoft-dark" => [
+        "background" => "#000000",
+        "border" => "#737373",
+        "stroke" => "#737373",
+        "ring" => "#7FBA00",
+        "fire" => "#F25022",
+        "currStreakNum" => "#00A4EF",
+        "sideNums" => "#FFB900",
+        "currStreakLabel" => "#00A4EF",
+        "sideLabels" => "#FFB900",
+        "dates" => "#7FBA00",
+        "excludeDaysLabel" => "#7FBA00",
+    ],
 ];


### PR DESCRIPTION
## Description

Add theme with Microsoft's logo colors both with light and dark backgrounds

### Type of change

- [x] New feature (added a non-breaking change which adds functionality)
- [x] Updated documentation (updated the readme, templates, or other repo files)

## How Has This Been Tested?

- [x] Ran tests with `composer test`

## Checklist:

- [x] I have checked to make sure no other [pull requests](https://github.com/DenverCoder1/github-readme-streak-stats/pulls?q=is%3Apr+sort%3Aupdated-desc+) are open for this issue
- [x] The code is properly formatted and is consistent with the existing code style
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Screenshots
### Dark variant
![image](https://github.com/user-attachments/assets/6454d744-d58a-487d-8de1-fe5b03f68851)
### Light variant
![image](https://github.com/user-attachments/assets/929524f1-7f1c-4cf4-8332-f16e12c14ed5)
