### PR TITLE
feat: Add option to use short number format

### DIFF
--- a/src/card.php
+++ b/src/card.php
@@ -343,7 +343,7 @@ function getCardHeight(array $params): int
  */
 function shortNumber(float $num): string
 {
-    $units = ['', 'K', 'M', 'B', 'T'];
+    $units = ["", "K", "M", "B", "T"];
     for ($i = 0; $num >= 1000; $i++) {
         $num /= 1000;
     }
@@ -433,16 +433,18 @@ function generateCard(array $stats, array $params = null): string
     ];
 
     // total contributions
-    $totalContributions = $params["short_total_contributions"] === "true"
-        ? shortNumber($stats["totalContributions"])
-        : $numFormatter->format($stats["totalContributions"]);
+    $totalContributions =
+        $params["short_total_contributions"] === "true"
+            ? shortNumber($stats["totalContributions"])
+            : $numFormatter->format($stats["totalContributions"]);
     $firstContribution = formatDate($stats["firstContribution"], $dateFormat, $localeCode);
     $totalContributionsRange = $firstContribution . " - " . $localeTranslations["Present"];
 
     // current streak
-    $currentStreak = $params["short_total_contributions"] === "true"
-        ? shortNumber($stats["currentStreak"]["length"])
-        : $numFormatter->format($stats["currentStreak"]["length"]);
+    $currentStreak =
+        $params["short_total_contributions"] === "true"
+            ? shortNumber($stats["currentStreak"]["length"])
+            : $numFormatter->format($stats["currentStreak"]["length"]);
     $currentStreakStart = formatDate($stats["currentStreak"]["start"], $dateFormat, $localeCode);
     $currentStreakEnd = formatDate($stats["currentStreak"]["end"], $dateFormat, $localeCode);
     $currentStreakRange = $currentStreakStart;
@@ -451,9 +453,10 @@ function generateCard(array $stats, array $params = null): string
     }
 
     // longest streak
-    $longestStreak = $params["short_total_contributions"] === "true"
-        ? shortNumber($stats["longestStreak"]["length"])
-        : $numFormatter->format($stats["longestStreak"]["length"]);
+    $longestStreak =
+        $params["short_total_contributions"] === "true"
+            ? shortNumber($stats["longestStreak"]["length"])
+            : $numFormatter->format($stats["longestStreak"]["length"]);
     $longestStreakStart = formatDate($stats["longestStreak"]["start"], $dateFormat, $localeCode);
     $longestStreakEnd = formatDate($stats["longestStreak"]["end"], $dateFormat, $localeCode);
     $longestStreakRange = $longestStreakStart;

--- a/src/card.php
+++ b/src/card.php
@@ -336,6 +336,21 @@ function getCardHeight(array $params): int
 }
 
 /**
+ * Convert large numbers into short form
+ *
+ * @param float $num The number to convert
+ * @return string The number in short form
+ */
+function shortNumber(float $num): string
+{
+    $units = ['', 'K', 'M', 'B', 'T'];
+    for ($i = 0; $num >= 1000; $i++) {
+        $num /= 1000;
+    }
+    return round($num, 1) . $units[$i];
+}
+
+/**
  * Generate SVG output for a stats array
  *
  * @param array<string,mixed> $stats Streak stats
@@ -418,12 +433,16 @@ function generateCard(array $stats, array $params = null): string
     ];
 
     // total contributions
-    $totalContributions = $numFormatter->format($stats["totalContributions"]);
+    $totalContributions = $params["short_total_contributions"] === "true"
+        ? shortNumber($stats["totalContributions"])
+        : $numFormatter->format($stats["totalContributions"]);
     $firstContribution = formatDate($stats["firstContribution"], $dateFormat, $localeCode);
     $totalContributionsRange = $firstContribution . " - " . $localeTranslations["Present"];
 
     // current streak
-    $currentStreak = $numFormatter->format($stats["currentStreak"]["length"]);
+    $currentStreak = $params["short_total_contributions"] === "true"
+        ? shortNumber($stats["currentStreak"]["length"])
+        : $numFormatter->format($stats["currentStreak"]["length"]);
     $currentStreakStart = formatDate($stats["currentStreak"]["start"], $dateFormat, $localeCode);
     $currentStreakEnd = formatDate($stats["currentStreak"]["end"], $dateFormat, $localeCode);
     $currentStreakRange = $currentStreakStart;
@@ -432,7 +451,9 @@ function generateCard(array $stats, array $params = null): string
     }
 
     // longest streak
-    $longestStreak = $numFormatter->format($stats["longestStreak"]["length"]);
+    $longestStreak = $params["short_total_contributions"] === "true"
+        ? shortNumber($stats["longestStreak"]["length"])
+        : $numFormatter->format($stats["longestStreak"]["length"]);
     $longestStreakStart = formatDate($stats["longestStreak"]["start"], $dateFormat, $localeCode);
     $longestStreakEnd = formatDate($stats["longestStreak"]["end"], $dateFormat, $localeCode);
     $longestStreakRange = $longestStreakStart;

--- a/src/card.php
+++ b/src/card.php
@@ -339,15 +339,20 @@ function getCardHeight(array $params): int
  * Convert large numbers into short form
  *
  * @param float $num The number to convert
+ * @param NumberFormatter $numFormatter Number formatter
  * @return string The number in short form
  */
-function shortNumber(float $num): string
+function shortNumber(float $num, NumberFormatter $numFormatter = null): string
 {
     $units = ["", "K", "M", "B", "T"];
     for ($i = 0; $num >= 1000; $i++) {
         $num /= 1000;
     }
-    return round($num, 1) . $units[$i];
+    $numeric = round($num, 1);
+    if ($numFormatter) {
+        $numeric = $numFormatter->format($numeric);
+    }
+    return $numeric . $units[$i];
 }
 
 /**
@@ -432,19 +437,19 @@ function generateCard(array $stats, array $params = null): string
         19.5 + $heightOffset,
     ];
 
+    $useShortNumbers = ($params["short_numbers"] ?? "") === "true";
+
     // total contributions
-    $totalContributions =
-        $params["short_total_contributions"] === "true"
-            ? shortNumber($stats["totalContributions"])
-            : $numFormatter->format($stats["totalContributions"]);
+    $totalContributions = $useShortNumbers
+        ? shortNumber($stats["totalContributions"], $numFormatter)
+        : $numFormatter->format($stats["totalContributions"]);
     $firstContribution = formatDate($stats["firstContribution"], $dateFormat, $localeCode);
     $totalContributionsRange = $firstContribution . " - " . $localeTranslations["Present"];
 
     // current streak
-    $currentStreak =
-        $params["short_total_contributions"] === "true"
-            ? shortNumber($stats["currentStreak"]["length"])
-            : $numFormatter->format($stats["currentStreak"]["length"]);
+    $currentStreak = $useShortNumbers
+        ? shortNumber($stats["currentStreak"]["length"], $numFormatter)
+        : $numFormatter->format($stats["currentStreak"]["length"]);
     $currentStreakStart = formatDate($stats["currentStreak"]["start"], $dateFormat, $localeCode);
     $currentStreakEnd = formatDate($stats["currentStreak"]["end"], $dateFormat, $localeCode);
     $currentStreakRange = $currentStreakStart;
@@ -453,10 +458,9 @@ function generateCard(array $stats, array $params = null): string
     }
 
     // longest streak
-    $longestStreak =
-        $params["short_total_contributions"] === "true"
-            ? shortNumber($stats["longestStreak"]["length"])
-            : $numFormatter->format($stats["longestStreak"]["length"]);
+    $longestStreak = $useShortNumbers
+        ? shortNumber($stats["longestStreak"]["length"], $numFormatter)
+        : $numFormatter->format($stats["longestStreak"]["length"]);
     $longestStreakStart = formatDate($stats["longestStreak"]["start"], $dateFormat, $localeCode);
     $longestStreakEnd = formatDate($stats["longestStreak"]["end"], $dateFormat, $localeCode);
     $longestStreakRange = $longestStreakStart;

--- a/src/card.php
+++ b/src/card.php
@@ -336,23 +336,26 @@ function getCardHeight(array $params): int
 }
 
 /**
- * Convert large numbers into short form
+ * Format number using locale and short number if requested
  *
- * @param float $num The number to convert
- * @param NumberFormatter $numFormatter Number formatter
- * @return string The number in short form
+ * @param float $num The number to format
+ * @param string $localeCode Locale code
+ * @param bool $useShortNumbers Whether to use short numbers
+ * @return string The formatted number
  */
-function shortNumber(float $num, NumberFormatter $numFormatter = null): string
+function formatNumber(float $num, string $localeCode, bool $useShortNumbers): string
 {
-    $units = ["", "K", "M", "B", "T"];
-    for ($i = 0; $num >= 1000; $i++) {
-        $num /= 1000;
+    $numFormatter = new NumberFormatter($localeCode, NumberFormatter::DECIMAL);
+    $suffix = "";
+    if ($useShortNumbers) {
+        $units = ["", "K", "M", "B", "T"];
+        for ($i = 0; $num >= 1000; $i++) {
+            $num /= 1000;
+        }
+        $suffix = $units[$i];
+        $num = round($num, 1);
     }
-    $numeric = round($num, 1);
-    if ($numFormatter) {
-        $numeric = $numFormatter->format($numeric);
-    }
-    return $numeric . $units[$i];
+    return $numFormatter->format($num) . $suffix;
 }
 
 /**
@@ -381,9 +384,6 @@ function generateCard(array $stats, array $params = null): string
     // get date format
     // locale date formatter (used only if date_format is not specified)
     $dateFormat = $params["date_format"] ?? ($localeTranslations["date_format"] ?? null);
-
-    // number formatter
-    $numFormatter = new NumberFormatter($localeCode, NumberFormatter::DECIMAL);
 
     // read border_radius parameter, default to 4.5 if not set
     $borderRadius = $params["border_radius"] ?? 4.5;
@@ -440,16 +440,12 @@ function generateCard(array $stats, array $params = null): string
     $useShortNumbers = ($params["short_numbers"] ?? "") === "true";
 
     // total contributions
-    $totalContributions = $useShortNumbers
-        ? shortNumber($stats["totalContributions"], $numFormatter)
-        : $numFormatter->format($stats["totalContributions"]);
+    $totalContributions = formatNumber($stats["totalContributions"], $localeCode, $useShortNumbers);
     $firstContribution = formatDate($stats["firstContribution"], $dateFormat, $localeCode);
     $totalContributionsRange = $firstContribution . " - " . $localeTranslations["Present"];
 
     // current streak
-    $currentStreak = $useShortNumbers
-        ? shortNumber($stats["currentStreak"]["length"], $numFormatter)
-        : $numFormatter->format($stats["currentStreak"]["length"]);
+    $currentStreak = formatNumber($stats["currentStreak"]["length"], $localeCode, $useShortNumbers);
     $currentStreakStart = formatDate($stats["currentStreak"]["start"], $dateFormat, $localeCode);
     $currentStreakEnd = formatDate($stats["currentStreak"]["end"], $dateFormat, $localeCode);
     $currentStreakRange = $currentStreakStart;
@@ -458,9 +454,7 @@ function generateCard(array $stats, array $params = null): string
     }
 
     // longest streak
-    $longestStreak = $useShortNumbers
-        ? shortNumber($stats["longestStreak"]["length"], $numFormatter)
-        : $numFormatter->format($stats["longestStreak"]["length"]);
+    $longestStreak = formatNumber($stats["longestStreak"]["length"], $localeCode, $useShortNumbers);
     $longestStreakStart = formatDate($stats["longestStreak"]["start"], $dateFormat, $localeCode);
     $longestStreakEnd = formatDate($stats["longestStreak"]["end"], $dateFormat, $localeCode);
     $longestStreakRange = $longestStreakStart;

--- a/src/demo/index.php
+++ b/src/demo/index.php
@@ -120,6 +120,12 @@ function camelToSkewer(string $str): string
                     <?php endforeach; ?>
                 </select>
 
+                <label for="short-numbers">Short Numbers</label>
+                <select class="param" id="short-numbers" name="short_numbers">
+                    <option>false</option>
+                    <option>true</option>
+                </select>
+
                 <label for="date-format">Date Format</label>
                 <select class="param" id="date-format" name="date_format">
                     <option value="">default</option>
@@ -172,12 +178,6 @@ function camelToSkewer(string $str): string
 
                 <label for="card-width">Card Height</label>
                 <input class="param" type="number" id="card-width" name="card_height" placeholder="195" value="195" step="1" min="170" />
-
-                <label for="short-total-contributions">Short Total Contributions</label>
-                <select class="param" id="short-total-contributions" name="short_total_contributions">
-                    <option>false</option>
-                    <option>true</option>
-                </select>
 
                 <label for="type">Output Type</label>
                 <select class="param" id="type" name="type">

--- a/src/demo/index.php
+++ b/src/demo/index.php
@@ -173,6 +173,12 @@ function camelToSkewer(string $str): string
                 <label for="card-width">Card Height</label>
                 <input class="param" type="number" id="card-width" name="card_height" placeholder="195" value="195" step="1" min="170" />
 
+                <label for="short-total-contributions">Short Total Contributions</label>
+                <select class="param" id="short-total-contributions" name="short_total_contributions">
+                    <option>false</option>
+                    <option>true</option>
+                </select>
+
                 <label for="type">Output Type</label>
                 <select class="param" id="type" name="type">
                     <option value="svg">SVG</option>

--- a/src/demo/js/script.js
+++ b/src/demo/js/script.js
@@ -19,6 +19,7 @@ const preview = {
     hide_total_contributions: "false",
     hide_current_streak: "false",
     hide_longest_streak: "false",
+    short_numbers: "false",
   },
 
   /**

--- a/tests/RenderTest.php
+++ b/tests/RenderTest.php
@@ -49,6 +49,11 @@ final class RenderTest extends TestCase
         $render = generateCard($this->testStats, $this->testParams);
         $expected = file_get_contents("tests/expected/test_card.svg");
         $this->assertEquals($expected, $render);
+
+        // Test short_total_contributions parameter
+        $this->testParams["short_total_contributions"] = "true";
+        $render = generateCard($this->testStats, $this->testParams);
+        $this->assertStringContainsString("2K", $render);
     }
 
     /**

--- a/tests/RenderTest.php
+++ b/tests/RenderTest.php
@@ -50,8 +50,8 @@ final class RenderTest extends TestCase
         $expected = file_get_contents("tests/expected/test_card.svg");
         $this->assertEquals($expected, $render);
 
-        // Test short_total_contributions parameter
-        $this->testParams["short_total_contributions"] = "true";
+        // Test short_numbers parameter
+        $this->testParams["short_numbers"] = "true";
         $render = generateCard($this->testStats, $this->testParams);
         $this->assertStringContainsString("2K", $render);
     }


### PR DESCRIPTION
Resolves #729 

This pull request introduces a new feature to display large numbers in a shortened format (e.g., 1K for 1,000) on the generated cards. The changes include the implementation of the short number formatting function, updates to the card generation logic, and modifications to the demo interface and tests to support this new feature.

Key changes:

### New Feature Implementation:

* Added `shortNumber` function in `src/card.php` to convert large numbers into a short form (e.g., 1K, 1M).

### Card Generation Logic:

* Updated `generateCard` function in `src/card.php` to use the `shortNumber` function when the `short_numbers` parameter is set to "true" [[1]](diffhunk://#diff-1ce15c620155c6dbfb5273d35fed74813bcbf66ce7927d36c291a592f79baa66R440-R452) [[2]](diffhunk://#diff-1ce15c620155c6dbfb5273d35fed74813bcbf66ce7927d36c291a592f79baa66L435-R463).

### Demo Interface:

* Added a "Short Numbers" option to the demo interface in `src/demo/index.php` to allow users to toggle the short number format.
* Updated `src/demo/js/script.js` to include the `short_numbers` parameter in the preview configuration.

### Testing:

* Updated `tests/RenderTest.php` to include a test case for the `short_numbers` parameter, ensuring the correct rendering of shortened numbers.