### PR TITLE
feat: add hacker-inverted theme

### DIFF
--- a/docs/themes.md
+++ b/docs/themes.md
@@ -162,6 +162,7 @@ Note: Theme names provided are case-insensitive and any use of underscores will 
 |      `telegram-gradient`      |                 ![image](https://github.com/user-attachments/assets/985c3e04-a5dd-4cba-a66e-d43ad9668af0)                  |
 |          `microsoft`          |                 ![image](https://github.com/user-attachments/assets/4c2cce9d-90b5-4e38-8422-656c5a78b4d9)                  |
 |       `microsoft-dark`        |                 ![image](https://github.com/user-attachments/assets/a5918d7d-f568-4012-b06f-d9cfacaece04)                  |
+|       `hacker-inverted`       |                 ![image](https://github.com/user-attachments/assets/b64c136a-827b-4177-98f9-28db59bba0ef)                  |
 
 ### Can't find the theme you like?
 

--- a/src/themes.php
+++ b/src/themes.php
@@ -2004,4 +2004,17 @@ return [
         "dates" => "#7FBA00",
         "excludeDaysLabel" => "#7FBA00",
     ],
+    "hacker-inverted" => [
+        "background" => "#20C20E",
+        "border" => "#000000",
+        "stroke" => "#000000",
+        "ring" => "#000000",
+        "fire" => "#000000",
+        "currStreakNum" => "#000000",
+        "sideNums" => "#000000",
+        "currStreakLabel" => "#000000",
+        "sideLabels" => "#000000",
+        "dates" => "#000000",
+        "excludeDaysLabel" => "#000000",
+    ],
 ];


### PR DESCRIPTION
## Description

Add `hacker-inverted` theme, it's just inverted version of `hacker` theme

### Type of change

- [x] New feature (added a non-breaking change which adds functionality)
- [x] Updated documentation (updated the readme, templates, or other repo files)

## How Has This Been Tested?

- [x] Tested locally with a valid username
- [x] Ran tests with `composer test`

## Checklist:

- [x] I have checked to make sure no other [pull requests](https://github.com/DenverCoder1/github-readme-streak-stats/pulls?q=is%3Apr+sort%3Aupdated-desc+) are open for this issue
- [x] The code is properly formatted and is consistent with the existing code style
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Screenshots

![image](https://github.com/user-attachments/assets/b64c136a-827b-4177-98f9-28db59bba0ef)
