### PR TITLE
fix: Updated Indonesian for Excluding translation

### DIFF
--- a/src/translations.php
+++ b/src/translations.php
@@ -232,7 +232,7 @@ return [
         "Week Streak" => "Aksi Mingguan",
         "Longest Week Streak" => "Aksi Mingguan Terpanjang",
         "Present" => "Sekarang",
-        "Excluding {days}" => "Tidak termasuk {days}",
+        "Excluding {days}" => "Kecuali {days}",
     ],
     "it" => [
         "Total Contributions" => "Contributi Totali",


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. -->

I made a change from `"Tidak termasuk {days}"` to `"Kecuali {days}"`. This was done because the equivalent of `"kecuali"` is more precise and clear to express exclusion in Indonesian. The word `"tidak termasuk"` can cause ambiguity because it literally only states that something is not included, whereas the word `"kecuali"` explicitly indicates that the days are excluded from the calculation or list. Thus, `"Kecuali {days}"` is easier to understand and directly conveys the overall intention of exclusion.

### Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (added a non-breaking change which fixes an issue)
- [ ] New feature (added a non-breaking change which adds functionality)
- [ ] Updated documentation (updated the readme, templates, or other repo files)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

<!--
If you have changed a feature of the stats cards, please describe the tests you made to verify your changes.
Changes strictly related to documentation can skip this section.
-->

- [x] Tested locally with a valid username
- [x] Tested locally with an invalid username
- [x] Ran tests with `composer test`
- [x] Added or updated test cases to test new features

## Checklist:

- [x] I have checked to make sure no other [pull requests](https://github.com/DenverCoder1/github-readme-streak-stats/pulls?q=is%3Apr+sort%3Aupdated-desc+) are open for this issue
- [x] The code is properly formatted and is consistent with the existing code style
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Screenshots

<!-- If you have updated the design or appearance, please include a screenshot of your changes. -->
_None_