### PR TITLE
fix: Updated Korean translations

### DIFF
--- a/src/translations.php
+++ b/src/translations.php
@@ -275,11 +275,11 @@ return [
     "ko" => [
         "Total Contributions" => "총 기여 수",
         "Current Streak" => "현재 연속 기여 수",
-        "Longest Streak" => "최대 연속 기여 수",
-        "Week Streak" => "주간 기여 수",
-        "Longest Week Streak" => "최대 주간 기여 수",
+        "Longest Streak" => "최장 연속 기여 수",
+        "Week Streak" => "주간 연속 기여 수",
+        "Longest Week Streak" => "최장 주간 연속 기여 수",
         "Present" => "현재",
-        "Excluding {days}" => "{days} 제외된",
+        "Excluding {days}" => "{days} 제외하고",
     ],
     "mr" => [
         "Total Contributions" => "एकूण योगदान",


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. -->

I made some big changes for this translation. Here's an explanation:
1. **Changes to the translation of `"Longest Streek"` and `"Longest Week Streak"`**
Previously used `"최대"` which literally means `"biggest"`. I changed it to `"최장"` which means `"longest"`. Also, added `"연속"` as the translation of `"streak"`.
2. **Changes to the translation of `"Week Streak"`**
Previously translated as `"주간 기여 수"` which only indicates the weekly contribution amount. I changed it to `"주간 연속 기여수"`. The addition of `"연속"` as a translation of `"streak"`.
3. **Changes to the translation of `"Excluding {days}"`**
Previously translated as `"{days} 제외된"`, which means "excluded {days}" (passive form), it is not precise in conveying the meaning of exclusion. I changed it to `"{days} 제외하고"`.

If this needs to be discussed again, please feel free.

### Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (added a non-breaking change which fixes an issue)
- [ ] New feature (added a non-breaking change which adds functionality)
- [ ] Updated documentation (updated the readme, templates, or other repo files)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

<!--
If you have changed a feature of the stats cards, please describe the tests you made to verify your changes.
Changes strictly related to documentation can skip this section.
-->

- [x] Tested locally with a valid username
- [x] Tested locally with an invalid username
- [x] Ran tests with `composer test`
- [x] Added or updated test cases to test new features

## Checklist:

- [x] I have checked to make sure no other [pull requests](https://github.com/DenverCoder1/github-readme-streak-stats/pulls?q=is%3Apr+sort%3Aupdated-desc+) are open for this issue
- [x] The code is properly formatted and is consistent with the existing code style
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Screenshots

<!-- If you have updated the design or appearance, please include a screenshot of your changes. -->
_None_