### PR TITLE
fix: Correct Traditional Chinese typo for 'Longest Week Streak'

### DIFF
--- a/src/translations.php
+++ b/src/translations.php
@@ -516,7 +516,7 @@ return [
         "Current Streak" => "目前連續貢獻",
         "Longest Streak" => "最長連續貢獻",
         "Week Streak" => "周連續貢獻",
-        "Longest Week Streak" => "最常周連續貢獻",
+        "Longest Week Streak" => "最長周連續貢獻",
         "Present" => "至今",
         "Excluding {days}" => "除外 {days}",
         "comma_separator" => "、",


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. -->

### Purpose of this PR
- Correct the Traditional Chinese translation for "Longest Week Streak" from `最常周連續貢獻` to `最長周連續貢獻`

### Character Usage Explanation
In Chinese: 
- **常 (cháng)** usually means "often/frequently" (e.g., 常常 = often) 
- **長 (cháng/zhǎng)** in this context:
  - When pronounced **cháng**, it means "long" in terms of **time duration** (e.g., 長時間 = long time)
  - When pronounced **zhǎng**, it means "grow" (e.g., 成長 = growth)

Since "Longest Week Streak" refers to **time duration**, `長` (cháng) is the correct character here. The previous `常` was a phonetic typo.

### 修改說明（中文備註）
原詞「常」為同音錯別字，正確應為表示時間長度的「長」，二者讀音相同但語義不同。

### Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (added a non-breaking change which fixes an issue)
- [ ] New feature (added a non-breaking change which adds functionality)
- [ ] Updated documentation (updated the readme, templates, or other repo files)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

<!--
If you have changed a feature of the stats cards, please describe the tests you made to verify your changes.
Changes strictly related to documentation can skip this section.
-->

- [x] Tested locally with a valid username
- [x] Tested locally with an invalid username
- [x] Ran tests with `composer test`
- [x] Added or updated test cases to test new features

## Checklist:

- [x] I have checked to make sure no other [pull requests](https://github.com/DenverCoder1/github-readme-streak-stats/pulls?q=is%3Apr+sort%3Aupdated-desc+) are open for this issue
- [x] The code is properly formatted and is consistent with the existing code style
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Screenshots

<!-- If you have updated the design or appearance, please include a screenshot of your changes. -->
