### PR TITLE
feat: add custom 404 page with redirect to main repository

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<meta
+  http-equiv="refresh"
+  content="0; url=https://github.com/DenverCoder1/github-readme-streak-stats"
+/>


### PR DESCRIPTION
## Description

Added custom 404 page that redirects users to the main repository, replacing Vercel's default error page for better user experience.

### Type of change

- [x] New feature (added a non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Tested in Vercel deployment with invalid URLs to verify redirect
- [x] Tested redirect functionality in different browsers

## Checklist:

- [x] I have checked to make sure no other [pull requests](https://github.com/DenverCoder1/github-readme-streak-stats/pulls?q=is%3Apr+sort%3Aupdated-desc+) are open for this issue
- [x] The code is properly formatted and is consistent with the existing code style
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings