### PR TITLE
docs: Added warning about Vercel branch deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Vercel is the recommended option for hosting the files since it is **free** and 
 #### Option 1: Deploy to Vercel quickly with the Deploy button (recommended)
 
 > [!IMPORTANT]
-> Make sure that you host the **vercel** branch as otherwise you'll get the 404 error from Vercel. You can set the vercel branch as default after forking the repo.
+> Make sure that you host the **`vercel`** branch as otherwise you'll get a 404 error from Vercel. You can set the `vercel` branch as default after forking the repo.
 
 1. Click the Deploy button below
 


### PR DESCRIPTION
## Description

Added a note to the Vercel installation section to remind users that they must deploy the 'vercel' branch to avoid 404 errors.

### Type of change

- [ ] Updated documentation (updated the readme, templates, or other repo files)

## Checklist:

- [ ] I have checked to make sure no other [pull requests](https://github.com/DenverCoder1/github-readme-streak-stats/pulls?q=is%3Apr+sort%3Aupdated-desc+) are open for this issue
- [ ] The code is properly formatted and is consistent with the existing code style
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

