### PR TITLE
feat: Add env variable for optionally disabling cache feature

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,8 @@
-# replace ghp_example with your GitHub PAT token
+# replace ghp_example with your GitHub PAT token (see README for instructions)
 TOKEN=ghp_example
+
+# optional: Add a comma-separated list of GitHub usernames to whitelist (only these users' streaks will be displayed)
+# WHITELIST=DenverCoder1
+
+# optional: disable caching (not recommended, may cause rate limit issues)
+# DISABLE_CACHE=true

--- a/src/index.php
+++ b/src/index.php
@@ -46,8 +46,11 @@ try {
         "exclude_days" => $excludeDaysRaw,
     ];
 
-    // Check for cached stats first (24 hour cache)
-    $cachedStats = getCachedStats($user, $cacheOptions);
+    // Check if cache is disabled
+    $useCache = !isset($_SERVER["DISABLE_CACHE"]) || strtolower($_SERVER["DISABLE_CACHE"]) !== "true";
+
+    // Check for cached stats first (24 hour cache) unless cache is disabled
+    $cachedStats = $useCache ? getCachedStats($user, $cacheOptions) : null;
 
     if ($cachedStats !== null) {
         // Use cached stats - instant response!
@@ -65,8 +68,10 @@ try {
             $stats = getContributionStats($contributions, $excludeDays);
         }
 
-        // Cache the stats for 24 hours
-        setCachedStats($user, $cacheOptions, $stats);
+        // Cache the stats for 24 hours unless cache is disabled
+        if ($useCache) {
+            setCachedStats($user, $cacheOptions, $stats);
+        }
     }
 
     renderOutput($stats);


### PR DESCRIPTION
This pull request introduces improvements to configuration flexibility and caching behavior in the project. The main changes allow users to customize caching and user whitelisting through environment variables, and ensure caching can be disabled via configuration.

Configuration enhancements:

* Added instructions and options to `.env.example` for whitelisting GitHub usernames and disabling caching, making setup and customization easier.

Caching logic improvements:

* Updated `src/index.php` to respect the `DISABLE_CACHE` environment variable, disabling caching when set to `"true"`.
* Modified caching logic in `src/index.php` to only cache stats when caching is enabled, preventing unnecessary cache writes.