### PR TITLE
Test docs themes

### DIFF
--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -45,6 +45,22 @@ final class OptionsTest extends TestCase
     }
 
     /**
+     * Test that all themes appear in the documentation (docs/themes.md)
+     */
+    public function testThemesInDocumentation(): void
+    {
+        $themes = include "src/themes.php";
+        $docContent = file_get_contents("docs/themes.md");
+        foreach (array_keys($themes) as $theme) {
+            $this->assertStringContainsString(
+                "`$theme`",
+                $docContent,
+                "The theme '$theme' is missing from the documentation (docs/themes.md)."
+            );
+        }
+    }
+
+    /**
      * Test fallback to default theme
      */
     public function testFallbackToDefaultTheme(): void
@@ -74,7 +90,7 @@ final class OptionsTest extends TestCase
             $this->assertEquals(
                 array_diff_key($colors, $this->defaultTheme),
                 [],
-                "The theme '$theme' contains invalid parameters.",
+                "The theme '$theme' contains invalid parameters."
             );
             # check that no parameters are missing and all values are valid
             foreach (array_keys($this->defaultTheme) as $param) {
@@ -85,7 +101,7 @@ final class OptionsTest extends TestCase
                     $this->assertMatchesRegularExpression(
                         $backgroundRegex,
                         $colors[$param],
-                        "The parameter '$param' of '$theme' is not a valid background value.",
+                        "The parameter '$param' of '$theme' is not a valid background value."
                     );
                     continue;
                 }
@@ -93,13 +109,13 @@ final class OptionsTest extends TestCase
                 $this->assertMatchesRegularExpression(
                     $hexRegex,
                     strtoupper($colors[$param]),
-                    "The parameter '$param' of '$theme' is not a valid hex color.",
+                    "The parameter '$param' of '$theme' is not a valid hex color."
                 );
                 // check that the key is a valid hex color in uppercase
                 $this->assertMatchesRegularExpression(
                     $hexRegex,
                     $colors[$param],
-                    "The parameter '$param' of '$theme' should not contain lowercase letters.",
+                    "The parameter '$param' of '$theme' should not contain lowercase letters."
                 );
             }
         }
@@ -251,7 +267,7 @@ final class OptionsTest extends TestCase
             $this->assertEquals(
                 $theme,
                 $normalized,
-                "Theme name '$theme' is not normalized. It should contain only lowercase letters, numbers, and dashes. Consider renaming it to '$normalized'.",
+                "Theme name '$theme' is not normalized. It should contain only lowercase letters, numbers, and dashes. Consider renaming it to '$normalized'."
             );
         }
     }

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -55,7 +55,7 @@ final class OptionsTest extends TestCase
             $this->assertStringContainsString(
                 "`$theme`",
                 $docContent,
-                "The theme '$theme' is missing from the documentation (docs/themes.md)."
+                "The theme '$theme' is missing from the documentation (docs/themes.md).",
             );
         }
     }
@@ -90,7 +90,7 @@ final class OptionsTest extends TestCase
             $this->assertEquals(
                 array_diff_key($colors, $this->defaultTheme),
                 [],
-                "The theme '$theme' contains invalid parameters."
+                "The theme '$theme' contains invalid parameters.",
             );
             # check that no parameters are missing and all values are valid
             foreach (array_keys($this->defaultTheme) as $param) {
@@ -101,7 +101,7 @@ final class OptionsTest extends TestCase
                     $this->assertMatchesRegularExpression(
                         $backgroundRegex,
                         $colors[$param],
-                        "The parameter '$param' of '$theme' is not a valid background value."
+                        "The parameter '$param' of '$theme' is not a valid background value.",
                     );
                     continue;
                 }
@@ -109,13 +109,13 @@ final class OptionsTest extends TestCase
                 $this->assertMatchesRegularExpression(
                     $hexRegex,
                     strtoupper($colors[$param]),
-                    "The parameter '$param' of '$theme' is not a valid hex color."
+                    "The parameter '$param' of '$theme' is not a valid hex color.",
                 );
                 // check that the key is a valid hex color in uppercase
                 $this->assertMatchesRegularExpression(
                     $hexRegex,
                     $colors[$param],
-                    "The parameter '$param' of '$theme' should not contain lowercase letters."
+                    "The parameter '$param' of '$theme' should not contain lowercase letters.",
                 );
             }
         }
@@ -267,7 +267,7 @@ final class OptionsTest extends TestCase
             $this->assertEquals(
                 $theme,
                 $normalized,
-                "Theme name '$theme' is not normalized. It should contain only lowercase letters, numbers, and dashes. Consider renaming it to '$normalized'."
+                "Theme name '$theme' is not normalized. It should contain only lowercase letters, numbers, and dashes. Consider renaming it to '$normalized'.",
             );
         }
     }


### PR DESCRIPTION
This pull request adds a new test to ensure that all defined themes are documented in `docs/themes.md`. This helps maintain consistency between the codebase and its documentation.

Documentation consistency:

* Added `testThemesInDocumentation` method to `tests/OptionsTest.php` to verify that every theme listed in `src/themes.php` appears in the documentation file `docs/themes.md`.