### PR TITLE
fix: update `CACHE_DIR` for vercel

### DIFF
--- a/api/cache.php
+++ b/api/cache.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 
 // Default cache duration: 24 hours (in seconds)
 define("CACHE_DURATION", 24 * 60 * 60);
-define("CACHE_DIR", __DIR__ . "/../cache");
+define("CACHE_DIR", "/tmp/cache");
 
 /**
  * Generate a cache key for a user's request


### PR DESCRIPTION
## Description

This PR updates the `vercel` branch to use a cache directory compatible with Vercel’s serverless runtime.

### What changed

- In `api/cache.php`, changed the cache directory from a project-relative path to `/tmp/cache`.
- This avoids `mkdir(): Read-only file system` warnings when deploying on Vercel, since the project filesystem is read-only and `/tmp` is the only writable location.

### Why

After the recent cache update, the following warnings showed up on my Vercel deployment due to which the card stopped rendering properly on my github readme:

```
Warning: mkdir(): Read-only file system in /var/task/user/api/cache.php on line 57

Warning: http_response_code(): Cannot set response code - headers already sent (output started at /var/task/user/api/cache.php:57) in /var/task/user/api/card.php on line 876

Warning: Cannot modify header information - headers already sent by (output started at /var/task/user/api/cache.php:57) in /var/task/user/api/card.php on line 877
```

- Vercel serverless functions run on a read-only filesystem; attempts to create or write to directories inside the project path fail and cause PHP warnings.
- Using `/tmp/cache` allows the file-based cache to work during a function’s lifetime without requiring any additional configuration from users.

### Notes

- This change is scoped to the `vercel` branch only.  
- If needed in the future, the cache directory could be made configurable via an environment variable (for example, `CACHE_DIR`), but this PR keeps the fix minimal.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [ ] Tested locally with a valid username  
- [ ] Tested locally with an invalid username  
- [ ] Ran tests with `composer test`  
- [ ] Added or updated test cases to test new features  
- [x] Tested on Vercel deployment

## Checklist

- [x] I have checked to make sure no other [pull requests](https://github.com/DenverCoder1/github-readme-streak-stats/pulls?q=is%3Apr+sort%3Aupdated-desc+) are open for this issue  
- [x] The code is properly formatted and is consistent with the existing code style  
- [ ] I have commented my code, particularly in hard-to-understand areas  
- [ ] I have made corresponding changes to the documentation  
- [x] My changes generate no new warnings  

