### PR TITLE
fix: Add timezone parameter to fix streak resets for UTC-negative users

### DIFF
--- a/src/demo/index.php
+++ b/src/demo/index.php
@@ -136,6 +136,14 @@ function camelToSkewer(string $str): string
                     <option value="[Y.]n.j">2016.8.10</option>
                 </select>
 
+                <label for="timezone">Timezone</label>
+                <input class="param" type="text" id="timezone" name="timezone" placeholder="Etc/UTC" list="timezone-list" />
+                <datalist id="timezone-list">
+                    <?php foreach (DateTimeZone::listIdentifiers() as $tz): ?>
+                        <option value="<?php echo $tz; ?>"></option>
+                    <?php endforeach; ?>
+                </datalist>
+
                 <label for="mode">Streak Mode</label>
                 <select class="param" id="mode" name="mode">
                     <option value="daily">Daily</option>

--- a/src/demo/js/script.js
+++ b/src/demo/js/script.js
@@ -11,6 +11,7 @@ const preview = {
     date_format: "",
     locale: "en",
     border_radius: "4.5",
+    timezone: "",
     mode: "daily",
     type: "svg",
     exclude_days: "",

--- a/src/index.php
+++ b/src/index.php
@@ -39,11 +39,16 @@ try {
     $mode = isset($_GET["mode"]) ? $_GET["mode"] : null;
     $excludeDaysRaw = $_GET["exclude_days"] ?? "";
 
+    // validate timezone parameter
+    $timezoneRaw = $_GET["timezone"] ?? "";
+    $timezone = in_array($timezoneRaw, DateTimeZone::listIdentifiers()) ? $timezoneRaw : null;
+
     // Build cache options based on request parameters
     $cacheOptions = [
         "starting_year" => $startingYear,
         "mode" => $mode,
         "exclude_days" => $excludeDaysRaw,
+        "timezone" => $timezone,
     ];
 
     // Check if cache is disabled
@@ -58,7 +63,7 @@ try {
     } else {
         // Fetch fresh data from GitHub API
         $contributionGraphs = getContributionGraphs($user, $startingYear);
-        $contributions = getContributionDates($contributionGraphs);
+        $contributions = getContributionDates($contributionGraphs, $timezone);
 
         if ($mode === "weekly") {
             $stats = getWeeklyContributionStats($contributions);

--- a/src/stats.php
+++ b/src/stats.php
@@ -252,13 +252,16 @@ function getGraphQLCurlHandle(string $query, string $token): CurlHandle
  * Get an array of all dates with the number of contributions
  *
  * @param array<int,stdClass> $contributionCalendars List of GraphQL response objects by year
+ * @param string|null $timezone IANA timezone identifier (e.g. "America/New_York")
  * @return array<string,int> Y-M-D dates mapped to the number of contributions
  */
-function getContributionDates(array $contributionGraphs): array
+function getContributionDates(array $contributionGraphs, ?string $timezone = null): array
 {
     $contributions = [];
-    $today = date("Y-m-d");
-    $tomorrow = date("Y-m-d", strtotime("tomorrow"));
+    $tz = $timezone ? new DateTimeZone($timezone) : null;
+    $now = $tz ? new DateTime("now", $tz) : new DateTime("now");
+    $today = $now->format("Y-m-d");
+    $tomorrow = (clone $now)->modify("+1 day")->format("Y-m-d");
     // sort contribution calendars by year key
     ksort($contributionGraphs);
     foreach ($contributionGraphs as $graph) {


### PR DESCRIPTION
## Summary
- Adds an optional `timezone` query parameter (IANA timezone, e.g. `America/New_York`) so "today" is evaluated in the user's local timezone instead of UTC
- Validates timezone against `DateTimeZone::listIdentifiers()` — invalid values fall back to server default
- Includes timezone in cache key so different timezones get separate cache entries
- Adds timezone input with autocomplete to the demo site

Fixes #884

## Test plan
- [ ] Append `&timezone=America/New_York` to a streak stats URL and verify "today" matches that timezone
- [ ] Verify no `timezone` param gives the same behavior as before (backwards compatible)
- [ ] Run `composer test` to confirm existing tests pass