### PR TITLE
fix: Remove unnecessary VCS repository causing Vercel auth failure

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,12 +12,6 @@
   "license": "MIT",
   "version": "1.6.0",
   "homepage": "https://github.com/DenverCoder1/github-readme-streak-stats",
-  "repositories": [
-      {
-          "type": "vcs",
-          "url": "https://github.com/DenverCoder1/github-readme-streak-stats"
-      }
-  ],
   "support": {
     "issues": "https://github.com/DenverCoder1/github-readme-streak-stats/issues",
     "source": "https://github.com/DenverCoder1/github-readme-streak-stats"


### PR DESCRIPTION
## Summary
- Removes the unnecessary `repositories` VCS entry in `composer.json` that points to the project's own GitHub repo
- This entry causes Composer to authenticate against GitHub when scanning the repo, which fails on Vercel without `COMPOSER_AUTH` set
- All actual dependencies (`vlucas/phpdotenv`, `phpunit/phpunit`) are resolved from Packagist and don't need this entry

Fixes #890

## Test plan
- [ ] Run `composer install` without any GitHub auth configured — should succeed since all deps are on Packagist
- [ ] Deploy to Vercel without `COMPOSER_AUTH` env var — should no longer fail at `AuthHelper.php line 132`