### PR TITLE
fix: Use /tmp for cache on Vercel's read-only filesystem

### DIFF
--- a/src/cache.php
+++ b/src/cache.php
@@ -10,7 +10,13 @@ declare(strict_types=1);
 
 // Default cache duration: 24 hours (in seconds)
 define("CACHE_DURATION", 24 * 60 * 60);
-define("CACHE_DIR", __DIR__ . "/../cache");
+
+// Use /tmp on Vercel since the deployment filesystem is read-only
+if (isset($_SERVER["VERCEL"]) && is_writable("/tmp")) {
+    define("CACHE_DIR", "/tmp/cache");
+} else {
+    define("CACHE_DIR", __DIR__ . "/../cache");
+}
 
 /**
  * Generate a cache key for a user's request


### PR DESCRIPTION
## Summary
- Detects Vercel environment via the `VERCEL` server variable and uses `/tmp/cache` as the cache directory instead of the default `../cache`
- Vercel's deployment filesystem is read-only, but `/tmp` is writable — this makes file-based caching actually work on Vercel instead of failing with PHP warnings that break the SVG output
- Falls back to the default cache directory on all other environments (no behavior change)

Fixes #869 (the PHP warning issue reported in the [latest comment](https://github.com/DenverCoder1/github-readme-streak-stats/issues/869#issuecomment-4148753271))

## Test plan
- [ ] On non-Vercel environments: cache directory unchanged (`../cache`), no behavior change
- [ ] On Vercel: cache uses `/tmp/cache`, no more `mkdir()` warnings, SVG renders correctly
- [ ] Caching works on Vercel — repeated requests within 24h return cached stats