### PR TITLE
Add GitHub Actions card generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,9 @@ on:
   schedule:
     - cron: "0 3 * * *"
   workflow_dispatch:
+  push:
+    paths:
+      - '.github/workflows/streak-stats.yml'
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -160,6 +160,51 @@ You can deploy the PHP files on any website server with PHP installed including 
 
 The Inkscape dependency is required for PNG rendering, as well as Segoe UI font for the intended rendering. If using Heroku, the buildpacks will install these for you automatically.
 
+### GitHub Actions
+
+GitHub Actions can generate a static SVG in your profile repository so your README does not depend on the public hosted endpoint. By default it uses `GITHUB_TOKEN`; if you need private contribution data, create a PAT and pass it as the `token` input.
+
+Create `/.github/workflows/streak-stats.yml` in your profile repo (`USERNAME/USERNAME`):
+
+```yaml
+name: Update streak stats
+
+on:
+  schedule:
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Generate streak stats
+        uses: DenverCoder1/github-readme-streak-stats@main
+        with:
+          options: user=${{ github.repository_owner }}&theme=dark&disable_animations=true
+          path: profile/streak.svg
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Commit streak stats
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add profile/streak.svg
+          git commit -m "Update streak stats" || exit 0
+          git push
+```
+
+Then embed the generated card from your profile README:
+
+```md
+![GitHub Streak](./profile/streak.svg)
+```
+
 ### [![Deploy to Vercel](https://github.com/DenverCoder1/github-readme-streak-stats/assets/20955511/5a503e6b-c462-4627-82ee-651f2cb2a1fc)][verceldeploy]
 
 Vercel is the recommended option for hosting the files since it is **free** and easy to set up. Watch the video below or expand the instructions to learn how to deploy to Vercel.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@
 
 ## ⚡ Quick setup
 
+### Option 1: Web Deployment
+
 1. Copy-paste the markdown below into your GitHub profile README
 2. Replace the value after `?user=` with your GitHub username
 
@@ -25,15 +27,82 @@
 [![GitHub Streak](https://streak-stats.demolab.com/?user=DenverCoder1)](https://git.io/streak-stats)
 ```
 
-3. Star the repo 😄
-
-### Next Steps
+#### Next Steps
 
 - Check out the [Demo Site](https://streak-stats.demolab.com) or [Options](https://github.com/DenverCoder1/github-readme-streak-stats?tab=readme-ov-file#-options) below for available customizations.
 
 - It is recommended to self-host the project more better reliability. See [Deploying it on your own](https://github.com/DenverCoder1/github-readme-streak-stats?tab=readme-ov-file#-deploying-it-on-your-own) for more details.
 
 [![][hspace]](#) [![Deploy to Heroku](https://www.herokucdn.com/deploy/button.svg)][herokudeploy] [![Deploy to Vercel](https://i.imgur.com/Mb3VLCi.png)][verceldeploy]
+
+### Option 2: GitHub Actions
+
+GitHub Actions can generate a static SVG in your profile repository so your README does not depend on the public hosted endpoint. If you need private contribution data, add a custom token to Repository Secrets using the steps below.
+
+<details>
+  <summary>Adding a Custom Token to Repository Secrets</summary><br/>
+
+1. Visit [this link](https://github.com/settings/tokens/new?description=GitHub%20Readme%20Streak%20Stats) to create a new Personal Access Token (no scopes required)
+2. Scroll to the bottom and click **"Generate token"**
+3. Visit your profile repository settings (Secrets and Variables > Actions) `https://github.com/[YOUR USERNAME]/[YOUR USERNAME]/settings/secrets/actions`
+4. Click "New Repository Secret" and create a secret with a custom name (eg. `STREAK_STATS_TOKEN`) and your token from step 2 as the value.
+5. Replace `${{ secrets.GITHUB_TOKEN }}` in the yml file below with `${{ secrets.STREAK_STATS_TOKEN }}` (using the custom name you gave the secret).
+
+</details>
+
+#### 1. Create the workflow file
+
+Create a folder in your repo named `.github` and within it a folder named `workflows` and add a file `/.github/workflows/streak-stats.yml` in your profile repo (`USERNAME/USERNAME`):
+
+```yaml
+name: Update streak stats
+
+on:
+  schedule:
+    - cron: "0 3 * * *"  # Run every day at 03:00
+  push:
+    paths:
+      - ".github/workflows/streak-stats.yml"  # Run any time this file is modified
+  workflow_dispatch:  # Run manually from the Actions tab
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Generate streak stats
+        uses: DenverCoder1/github-readme-streak-stats@main
+        with:
+          options: user=${{ github.repository_owner }}&theme=default&disable_animations=true
+          path: profile/streak.svg
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Commit streak stats
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add profile/streak.svg
+          git commit -m "Update streak stats" || exit 0
+          git push
+```
+
+#### 2. Show the generated stats in your README
+
+Add this to your profile `README.md` file where you want the stats to appear:
+
+```html
+<a href="https://git.io/streak-stats"><img src="./profile/streak.svg" alt="GitHub Streak" /></a>
+```
+
+If you are using a fork, replace `DenverCoder1` with the account or organization that hosts your fork. Do not put a PAT directly in the workflow file; store it in GitHub Secrets and reference it as `${{ secrets.YOUR_SECRET_NAME }}`.
+
+#### Next Steps
+
+- Check out the [Options](https://github.com/DenverCoder1/github-readme-streak-stats?tab=readme-ov-file#-options) below for available customizations.
 
 ## ⚙ Demo Site
 
@@ -152,7 +221,7 @@ The current streak is the number of consecutive days ending with the current day
 
 ## 📤 Deploying it on your own
 
-It is preferable to host the files on your own server and it takes less than 2 minutes to set up.
+It is preferable to either use [GitHub Actions](https://github.com/DenverCoder1/github-readme-streak-stats?tab=readme-ov-file#option-2-github-actions), or host the files on your own server which takes less than 2 minutes to set up.
 
 Doing this can lead to better uptime and more control over customization (you can modify the code for your usage).
 
@@ -160,59 +229,7 @@ You can deploy the PHP files on any website server with PHP installed including 
 
 The Inkscape dependency is required for PNG rendering, as well as Segoe UI font for the intended rendering. If using Heroku, the buildpacks will install these for you automatically.
 
-### GitHub Actions
-
-GitHub Actions can generate a static SVG in your profile repository so your README does not depend on the public hosted endpoint. By default it uses `GITHUB_TOKEN`; if you need private contribution data, create a PAT, save it as a repository secret, and pass that secret as the `token` input.
-
-Create `/.github/workflows/streak-stats.yml` in your profile repo (`USERNAME/USERNAME`):
-
-```yaml
-name: Update streak stats
-
-on:
-  schedule:
-    - cron: "0 3 * * *"
-  workflow_dispatch:
-  push:
-    paths:
-      - ".github/workflows/streak-stats.yml"
-
-jobs:
-  build:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Generate streak stats
-        uses: DenverCoder1/github-readme-streak-stats@main
-        with:
-          options: user=${{ github.repository_owner }}&theme=default&disable_animations=true
-          path: profile/streak.svg
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Commit streak stats
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add profile/streak.svg
-          git commit -m "Update streak stats" || exit 0
-          git push
-```
-
-#### Show the generated stats in your README
-
-Add this to your profile `README.md` file where you want the stats to appear:
-
-```html
-<a href="https://git.io/streak-stats"><img src="./profile/streak.svg" alt="GitHub Streak" /></a>
-```
-
-If you are using a fork, replace `DenverCoder1` with the account or organization that hosts your fork. Do not put a PAT directly in the workflow file; store it in GitHub Secrets and reference it as `${{ secrets.YOUR_SECRET_NAME }}`.
-
-### [![Deploy to Vercel](https://github.com/DenverCoder1/github-readme-streak-stats/assets/20955511/5a503e6b-c462-4627-82ee-651f2cb2a1fc)][verceldeploy]
+### Deploy to Vercel
 
 Vercel is the recommended option for hosting the files since it is **free** and easy to set up. Watch the video below or expand the instructions to learn how to deploy to Vercel.
 
@@ -270,7 +287,7 @@ Vercel is the recommended option for hosting the files since it is **free** and 
 
 </details>
 
-### [![Deploy on Heroku](https://github.com/DenverCoder1/github-readme-streak-stats/assets/20955511/e8b575af-5746-4200-a295-7e7baa448383)][herokudeploy]
+### Deploy on Heroku
 
 Heroku is another great option for hosting the files. All features are supported on Heroku and it is where the default domain is hosted. Heroku is not free, however, and you will need to pay between \$5 and \$7 per month to keep the app running. Expand the instructions below to learn how to deploy to Heroku.
 
@@ -296,7 +313,7 @@ Heroku is another great option for hosting the files. All features are supported
 
 </details>
 
-### ![Deploy on your own](https://github.com/DenverCoder1/github-readme-streak-stats/assets/20955511/e36ed842-ab56-473a-83fd-ace5bf968996)
+### Deploy on your own
 
 You can transfer the files to any webserver using FTP or other means, then refer to [CONTRIBUTING.md](/CONTRIBUTING.md) for installation steps.
 

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ on:
   workflow_dispatch:
   push:
     paths:
-      - '.github/workflows/streak-stats.yml'
+      - ".github/workflows/streak-stats.yml"
 
 jobs:
   build:
@@ -202,10 +202,12 @@ jobs:
           git push
 ```
 
-Then embed the generated card from your profile README:
+#### Show the generated stats in your README
 
-```md
-![GitHub Streak](./profile/streak.svg)
+Add this to your profile `README.md` file where you want the stats to appear:
+
+```html
+<a href="https://git.io/streak-stats"><img src="./profile/streak.svg" alt="GitHub Streak" /></a>
 ```
 
 If you are using a fork, replace `DenverCoder1` with the account or organization that hosts your fork. Do not put a PAT directly in the workflow file; store it in GitHub Secrets and reference it as `${{ secrets.YOUR_SECRET_NAME }}`.

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ The Inkscape dependency is required for PNG rendering, as well as Segoe UI font 
 
 ### GitHub Actions
 
-GitHub Actions can generate a static SVG in your profile repository so your README does not depend on the public hosted endpoint. By default it uses `GITHUB_TOKEN`; if you need private contribution data, create a PAT and pass it as the `token` input.
+GitHub Actions can generate a static SVG in your profile repository so your README does not depend on the public hosted endpoint. By default it uses `GITHUB_TOKEN`; if you need private contribution data, create a PAT, save it as a repository secret, and pass that secret as the `token` input.
 
 Create `/.github/workflows/streak-stats.yml` in your profile repo (`USERNAME/USERNAME`):
 
@@ -186,7 +186,7 @@ jobs:
       - name: Generate streak stats
         uses: DenverCoder1/github-readme-streak-stats@main
         with:
-          options: user=${{ github.repository_owner }}&theme=dark&disable_animations=true
+          options: user=${{ github.repository_owner }}&theme=default&disable_animations=true
           path: profile/streak.svg
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -204,6 +204,8 @@ Then embed the generated card from your profile README:
 ```md
 ![GitHub Streak](./profile/streak.svg)
 ```
+
+If you are using a fork, replace `DenverCoder1` with the account or organization that hosts your fork. Do not put a PAT directly in the workflow file; store it in GitHub Secrets and reference it as `${{ secrets.YOUR_SECRET_NAME }}`.
 
 ### [![Deploy to Vercel](https://github.com/DenverCoder1/github-readme-streak-stats/assets/20955511/5a503e6b-c462-4627-82ee-651f2cb2a1fc)][verceldeploy]
 

--- a/README.md
+++ b/README.md
@@ -59,11 +59,11 @@ name: Update streak stats
 
 on:
   schedule:
-    - cron: "0 3 * * *"  # Run every day at 03:00
+    - cron: "0 3 * * *" # Run every day at 03:00
   push:
     paths:
-      - ".github/workflows/streak-stats.yml"  # Run any time this file is modified
-  workflow_dispatch:  # Run manually from the Actions tab
+      - ".github/workflows/streak-stats.yml" # Run any time this file is modified
+  workflow_dispatch: # Run manually from the Actions tab
 
 jobs:
   build:

--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,7 @@ runs:
               php-version: "8.3"
               extensions: intl, curl
               coverage: none
+              github-token: ""
 
         - name: Install dependencies
           run: composer install --no-dev --no-interaction --prefer-dist --optimize-autoloader

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,46 @@
+name: GitHub Readme Streak Stats Action
+description: Generate a GitHub Readme Streak Stats SVG in GitHub Actions.
+author: DenverCoder1
+inputs:
+    options:
+        description: Card options as a query string or JSON object.
+        required: false
+        default: ""
+    path:
+        description: Output path for the SVG file.
+        required: false
+        default: "profile/streak.svg"
+    token:
+        description: GitHub token (PAT or GITHUB_TOKEN).
+        required: false
+        default: ""
+outputs:
+    path:
+        description: Path where the SVG file was written.
+        value: ${{ steps.generate.outputs.path }}
+runs:
+    using: composite
+    steps:
+        - name: Setup PHP
+          uses: shivammathur/setup-php@v2
+          with:
+              php-version: "8.3"
+              extensions: intl, curl
+              coverage: none
+
+        - name: Install dependencies
+          run: composer install --no-dev --no-interaction --prefer-dist --optimize-autoloader
+          shell: bash
+          working-directory: ${{ github.action_path }}
+
+        - name: Generate streak card
+          id: generate
+          run: php ${{ github.action_path }}/bin/generate-card.php
+          shell: bash
+          env:
+              INPUT_OPTIONS: ${{ inputs.options }}
+              INPUT_PATH: ${{ inputs.path }}
+              TOKEN: ${{ inputs.token || github.token }}
+branding:
+    icon: activity
+    color: orange

--- a/bin/generate-card.php
+++ b/bin/generate-card.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+$root = dirname(__DIR__);
+
+require_once "{$root}/vendor/autoload.php";
+require_once "{$root}/src/stats.php";
+require_once "{$root}/src/card.php";
+require_once "{$root}/src/cache.php";
+require_once "{$root}/src/generator.php";
+
+$dotenv = \Dotenv\Dotenv::createImmutable($root);
+$dotenv->safeLoad();
+
+/**
+ * Get an environment variable as a nullable string.
+ */
+function readEnv(string $name): ?string
+{
+    $value = getenv($name);
+    return $value === false || $value === "" ? null : $value;
+}
+
+/**
+ * Parse action options from a query string or JSON object.
+ *
+ * @return array<string,string>
+ */
+function parseActionOptions(string $value): array
+{
+    $value = trim($value);
+    if ($value === "") {
+        return [];
+    }
+
+    if (str_starts_with($value, "{")) {
+        $decoded = json_decode($value, true);
+        if (!is_array($decoded)) {
+            throw new InvalidArgumentException("Invalid JSON in options.", 1);
+        }
+        $options = $decoded;
+    } else {
+        parse_str(ltrim($value, "?"), $options);
+    }
+
+    $normalized = [];
+    foreach ($options as $key => $optionValue) {
+        if ($optionValue === null) {
+            continue;
+        }
+        $normalized[$key] = is_array($optionValue) ? implode(",", $optionValue) : strval($optionValue);
+    }
+
+    return $normalized;
+}
+
+$args = getopt("", ["options::", "path::"]);
+$optionsInput = strval($args["options"] ?? (readEnv("INPUT_OPTIONS") ?? ""));
+$outputPath = strval($args["path"] ?? (readEnv("INPUT_PATH") ?? "profile/streak.svg"));
+
+try {
+    if (!isset($_SERVER["TOKEN"]) && readEnv("TOKEN") !== null) {
+        $_SERVER["TOKEN"] = readEnv("TOKEN");
+    }
+    if (!isset($_SERVER["TOKEN"]) && readEnv("GITHUB_TOKEN") !== null) {
+        $_SERVER["TOKEN"] = readEnv("GITHUB_TOKEN");
+    }
+    if (!isset($_SERVER["TOKEN"])) {
+        throw new RuntimeException("Missing GitHub token. Pass the action token input or set TOKEN.");
+    }
+
+    $params = parseActionOptions($optionsInput);
+    if (!isset($params["user"]) && readEnv("GITHUB_REPOSITORY_OWNER") !== null) {
+        $params["user"] = readEnv("GITHUB_REPOSITORY_OWNER");
+    }
+    if (($params["type"] ?? "svg") !== "svg") {
+        throw new InvalidArgumentException("GitHub Actions generation supports SVG output only.", 1);
+    }
+
+    $stats = generateStreakStats($params["user"] ?? "", $params);
+    $response = generateOutput($stats, $params);
+
+    $outputDir = dirname($outputPath);
+    if ($outputDir !== "." && !is_dir($outputDir) && !mkdir($outputDir, 0755, true)) {
+        throw new RuntimeException("Failed to create output directory: {$outputDir}");
+    }
+    if (file_put_contents($outputPath, $response["body"]) === false) {
+        throw new RuntimeException("Failed to write output file: {$outputPath}");
+    }
+
+    $githubOutput = readEnv("GITHUB_OUTPUT");
+    if ($githubOutput !== null) {
+        file_put_contents($githubOutput, "path={$outputPath}\n", FILE_APPEND);
+    }
+
+    fwrite(STDOUT, "Wrote {$outputPath}\n");
+} catch (Throwable $error) {
+    fwrite(STDERR, $error->getMessage() . "\n");
+    exit(1);
+}

--- a/src/generator.php
+++ b/src/generator.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Generate streak stats for a GitHub user from request-style parameters.
+ *
+ * @param string $user GitHub username to get stats for
+ * @param array<string,mixed> $params Options that affect fetching and streak calculation
+ * @return array<string,mixed> The calculated streak stats
+ */
+function generateStreakStats(string $user, array $params = []): array
+{
+    $user = preg_replace("/[^a-zA-Z0-9\-]/", "", $user);
+    if ($user === "") {
+        throw new InvalidArgumentException("GitHub username is required.", 400);
+    }
+
+    $startingYear = isset($params["starting_year"]) ? intval($params["starting_year"]) : null;
+    $mode = isset($params["mode"]) ? strval($params["mode"]) : null;
+    $excludeDaysRaw = isset($params["exclude_days"]) ? strval($params["exclude_days"]) : "";
+
+    // Build cache options based on request parameters
+    $cacheOptions = [
+        "starting_year" => $startingYear,
+        "mode" => $mode,
+        "exclude_days" => $excludeDaysRaw,
+    ];
+
+    // Check if cache is disabled
+    $useCache = !isset($_SERVER["DISABLE_CACHE"]) || strtolower(strval($_SERVER["DISABLE_CACHE"])) !== "true";
+
+    // Check for cached stats first (24 hour cache) unless cache is disabled
+    $cachedStats = $useCache ? getCachedStats($user, $cacheOptions) : null;
+
+    if ($cachedStats !== null) {
+        return $cachedStats;
+    }
+
+    // Fetch fresh data from GitHub API
+    $contributionGraphs = getContributionGraphs($user, $startingYear);
+    $contributions = getContributionDates($contributionGraphs);
+
+    if ($mode === "weekly") {
+        $stats = getWeeklyContributionStats($contributions);
+    } else {
+        // split and normalize excluded days
+        $excludeDays = normalizeDays(explode(",", $excludeDaysRaw));
+        $stats = getContributionStats($contributions, $excludeDays);
+    }
+
+    // Cache the stats for 24 hours unless cache is disabled
+    if ($useCache) {
+        setCachedStats($user, $cacheOptions, $stats);
+    }
+
+    return $stats;
+}

--- a/src/index.php
+++ b/src/index.php
@@ -7,6 +7,7 @@ require_once "../vendor/autoload.php";
 require_once "stats.php";
 require_once "card.php";
 require_once "cache.php";
+require_once "generator.php";
 
 // load .env
 $dotenv = \Dotenv\Dotenv::createImmutable(dirname(__DIR__, 1));
@@ -33,47 +34,7 @@ if (!isset($_REQUEST["user"])) {
 }
 
 try {
-    // get streak stats for user given in query string
-    $user = preg_replace("/[^a-zA-Z0-9\-]/", "", $_REQUEST["user"]);
-    $startingYear = isset($_REQUEST["starting_year"]) ? intval($_REQUEST["starting_year"]) : null;
-    $mode = isset($_GET["mode"]) ? $_GET["mode"] : null;
-    $excludeDaysRaw = $_GET["exclude_days"] ?? "";
-
-    // Build cache options based on request parameters
-    $cacheOptions = [
-        "starting_year" => $startingYear,
-        "mode" => $mode,
-        "exclude_days" => $excludeDaysRaw,
-    ];
-
-    // Check if cache is disabled
-    $useCache = !isset($_SERVER["DISABLE_CACHE"]) || strtolower($_SERVER["DISABLE_CACHE"]) !== "true";
-
-    // Check for cached stats first (24 hour cache) unless cache is disabled
-    $cachedStats = $useCache ? getCachedStats($user, $cacheOptions) : null;
-
-    if ($cachedStats !== null) {
-        // Use cached stats - instant response!
-        $stats = $cachedStats;
-    } else {
-        // Fetch fresh data from GitHub API
-        $contributionGraphs = getContributionGraphs($user, $startingYear);
-        $contributions = getContributionDates($contributionGraphs);
-
-        if ($mode === "weekly") {
-            $stats = getWeeklyContributionStats($contributions);
-        } else {
-            // split and normalize excluded days
-            $excludeDays = normalizeDays(explode(",", $excludeDaysRaw));
-            $stats = getContributionStats($contributions, $excludeDays);
-        }
-
-        // Cache the stats for 24 hours unless cache is disabled
-        if ($useCache) {
-            setCachedStats($user, $cacheOptions, $stats);
-        }
-    }
-
+    $stats = generateStreakStats($_REQUEST["user"], $_REQUEST);
     renderOutput($stats);
 } catch (InvalidArgumentException | AssertionError $error) {
     error_log("Error {$error->getCode()}: {$error->getMessage()}");


### PR DESCRIPTION
## Summary

- Add first-party GitHub Actions support for generating static streak stats SVGs directly from this repository.
- Reuse the existing PHP stats, cache, and card rendering logic through a small shared generator function and CLI entrypoint.
- Document how profile repositories can generate and commit `profile/streak.svg` without depending on the public hosted endpoint.

## Test plan

- Ran `npx prettier --check README.md action.yml src/index.php src/generator.php bin/generate-card.php`.
- Verified the action in a profile repository with `workflow_dispatch`; it generated and committed `profile/streak.svg`.
- Confirmed the generated card can be embedded from README via `![GitHub Streak](./profile/streak.svg)`.

## Notes

- The workflow example uses `GITHUB_TOKEN` by default.
- For private contribution data, users should store a PAT in GitHub Secrets and reference it from the `token` input.