### PR TITLE
fix: read WHITELIST from $_ENV so it works on Vercel

### DIFF
--- a/src/whitelist.php
+++ b/src/whitelist.php
@@ -8,6 +8,6 @@
  */
 function isWhitelisted(string $user): bool
 {
-    $whitelist = array_map("trim", array_filter(explode(",", $_SERVER["WHITELIST"] ?? "")));
+    $whitelist = array_map("trim", array_filter(explode(",", $_ENV["WHITELIST"] ?? "")));
     return empty($whitelist) || in_array($user, $whitelist, true);
 }

--- a/src/whitelist.php
+++ b/src/whitelist.php
@@ -8,6 +8,7 @@
  */
 function isWhitelisted(string $user): bool
 {
-    $whitelist = array_map("trim", array_filter(explode(",", $_ENV["WHITELIST"] ?? "")));
+    $whitelistRaw = $_ENV["WHITELIST"] ?? $_SERVER["WHITELIST"] ?? (getenv("WHITELIST") ?: "");
+    $whitelist = array_map("trim", array_filter(explode(",", $whitelistRaw)));
     return empty($whitelist) || in_array($user, $whitelist, true);
 }

--- a/src/whitelist.php
+++ b/src/whitelist.php
@@ -8,7 +8,11 @@
  */
 function isWhitelisted(string $user): bool
 {
-    $whitelistRaw = $_ENV["WHITELIST"] ?? $_SERVER["WHITELIST"] ?? (getenv("WHITELIST") ?: "");
+    $whitelistRaw = $_ENV["WHITELIST"] ?? $_SERVER["WHITELIST"] ?? null;
+    if ($whitelistRaw === null) {
+        $whitelistRaw = getenv("WHITELIST");
+        $whitelistRaw = $whitelistRaw === false ? "" : $whitelistRaw;
+    }
     $whitelist = array_map("trim", array_filter(explode(",", $whitelistRaw)));
     return empty($whitelist) || in_array($user, $whitelist, true);
 }

--- a/src/whitelist.php
+++ b/src/whitelist.php
@@ -8,7 +8,7 @@
  */
 function isWhitelisted(string $user): bool
 {
-    $whitelistRaw = $_ENV["WHITELIST"] ?? $_SERVER["WHITELIST"] ?? null;
+    $whitelistRaw = $_ENV["WHITELIST"] ?? ($_SERVER["WHITELIST"] ?? null);
     if ($whitelistRaw === null) {
         $whitelistRaw = getenv("WHITELIST");
         $whitelistRaw = $whitelistRaw === false ? "" : $whitelistRaw;


### PR DESCRIPTION
## Description

When loading whitelists, change from `$_SERVER` to `$_ENV` so Vercel's env can be read.

Fixes #911

### Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (added a non-breaking change which fixes an issue)
- [ ] New feature (added a non-breaking change which adds functionality)
- [ ] Updated documentation (updated the readme, templates, or other repo files)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

<!--
If you have changed a feature of the stats cards, please describe the tests you made to verify your changes.
Changes strictly related to documentation can skip this section.
-->

- [x] Tested locally with a valid username
- [x] Tested locally with an invalid username
- [x] Ran tests with `composer test`
- [ ] Added or updated test cases to test new features

## Checklist:

- [x] I have checked to make sure no other [pull requests](https://github.com/DenverCoder1/github-readme-streak-stats/pulls?q=is%3Apr+sort%3Aupdated-desc+) are open for this issue
- [x] The code is properly formatted and is consistent with the existing code style
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Screenshots
