### PR TITLE
fix: Resolve nullable parameter deprecation issue in PHP 8.4

### DIFF
--- a/src/card.php
+++ b/src/card.php
@@ -367,7 +367,7 @@ function formatNumber(float $num, string $localeCode, bool $useShortNumbers): st
  *
  * @throws InvalidArgumentException If a locale does not exist
  */
-function generateCard(array $stats, array $params = null): string
+function generateCard(array $stats, ?array $params = null): string
 {
     $params = $params ?? $_REQUEST;
 
@@ -615,7 +615,7 @@ function generateCard(array $stats, array $params = null): string
  * @param array<string,string>|NULL $params Request parameters
  * @return string The generated SVG error card
  */
-function generateErrorCard(string $message, array $params = null): string
+function generateErrorCard(string $message, ?array $params = null): string
 {
     $params = $params ?? $_REQUEST;
 
@@ -807,7 +807,7 @@ function convertSvgToPng(string $svg, int $cardWidth, int $cardHeight): string
  * @param int $errorCode The HTTP error code (used for JSON responses)
  * @return array The Content-Type header and the response body, and status code in case of an error
  */
-function generateOutput(string|array $output, array $params = null, int $errorCode = 200): array
+function generateOutput(string|array $output, ?array $params = null, int $errorCode = 200): array
 {
     $params = $params ?? $_REQUEST;
 


### PR DESCRIPTION
## Description

This pull request makes minor improvements to function signatures in `src/card.php` by updating parameter type hints for better type safety and clarity. Specifically, it changes the default type of optional array parameters from `array $params = null` to `?array $params = null` in several functions. No functional behavior is changed.

### Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (added a non-breaking change which fixes an issue)
- [ ] New feature (added a non-breaking change which adds functionality)
- [ ] Updated documentation (updated the readme, templates, or other repo files)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

<!--
If you have changed a feature of the stats cards, please describe the tests you made to verify your changes.
Changes strictly related to documentation can skip this section.
-->

- [ ] Tested locally with a valid username
- [ ] Tested locally with an invalid username
- [ ] Ran tests with `composer test`
- [ ] Added or updated test cases to test new features

## Checklist:

- [ ] I have checked to make sure no other [pull requests](https://github.com/DenverCoder1/github-readme-streak-stats/pulls?q=is%3Apr+sort%3Aupdated-desc+) are open for this issue
- [ ] The code is properly formatted and is consistent with the existing code style
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

## Screenshots

<!-- If you have updated the design or appearance, please include a screenshot of your changes. -->
