### PR TITLE
Add Docker publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,53 @@
+name: Docker Publish
+
+on:
+    workflow_dispatch:
+    pull_request:
+    push:
+        branches:
+            - main
+        tags:
+            - "v*"
+
+env:
+    REGISTRY: ghcr.io
+    IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+    docker:
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            packages: write
+
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
+
+            - name: Log in to GitHub Container Registry
+              if: github.event_name != 'pull_request'
+              uses: docker/login-action@v4
+              with:
+                  registry: ${{ env.REGISTRY }}
+                  username: ${{ github.actor }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Extract Docker metadata
+              id: meta
+              uses: docker/metadata-action@v6
+              with:
+                  images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+                  tags: |
+                      type=ref,event=branch
+                      type=ref,event=pr
+                      type=semver,pattern={{version}}
+                      type=semver,pattern={{major}}.{{minor}}
+                      type=sha
+
+            - name: Build and push Docker image
+              uses: docker/build-push-action@v7
+              with:
+                  context: .
+                  push: ${{ github.event_name != 'pull_request' }}
+                  tags: ${{ steps.meta.outputs.tags }}
+                  labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Summary
- Add a Docker Publish GitHub Actions workflow for the existing Dockerfile
- Build Docker images for pull requests without publishing them
- Publish images to GitHub Container Registry on pushes to main, version tags, and manual runs

Closes #908

## Tests
- npx prettier --check .github/workflows/docker-publish.yml
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/docker-publish.yml'); puts 'valid yaml'"
- git diff --check

## Notes
- This was statically validated locally. A real publish run requires GitHub Actions package permissions in the upstream repository.