### PR TITLE
Count repository creation contributions in streaks

### DIFF
--- a/src/stats.php
+++ b/src/stats.php
@@ -28,6 +28,11 @@ function buildContributionGraphQuery(string $user, int $year): string
                         }
                     }
                 }
+                repositoryContributions(first: 100) {
+                    nodes {
+                        occurredAt
+                    }
+                }
             }
         }
     }";
@@ -275,7 +280,15 @@ function getContributionDates(array $contributionGraphs): array
                 }
             }
         }
+        $repositoryContributions = $graph->data->user->contributionsCollection->repositoryContributions->nodes ?? [];
+        foreach ($repositoryContributions as $repositoryContribution) {
+            $date = substr($repositoryContribution->occurredAt, 0, 10);
+            if ($date <= $today || $date == $tomorrow) {
+                $contributions[$date] = max($contributions[$date] ?? 0, 1);
+            }
+        }
     }
+    ksort($contributions);
     return $contributions;
 }
 

--- a/tests/StatsTest.php
+++ b/tests/StatsTest.php
@@ -321,6 +321,72 @@ final class StatsTest extends TestCase
     }
 
     /**
+     * Test repository creation keeps daily streak active
+     */
+    public function testRepositoryCreationContribution(): void
+    {
+        $contributionGraphs = [
+            (object) [
+                "data" => (object) [
+                    "user" => (object) [
+                        "contributionsCollection" => (object) [
+                            "contributionCalendar" => (object) [
+                                "weeks" => (object) [
+                                    (object) [
+                                        "contributionDays" => (object) [
+                                            (object) [
+                                                "contributionCount" => 2,
+                                                "date" => "2026-07-08",
+                                            ],
+                                            (object) [
+                                                "contributionCount" => 0,
+                                                "date" => "2026-07-09",
+                                            ],
+                                            (object) [
+                                                "contributionCount" => 3,
+                                                "date" => "2026-07-10",
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                            "repositoryContributions" => (object) [
+                                "nodes" => [
+                                    (object) [
+                                        "occurredAt" => "2026-07-09T12:00:00Z",
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $contributions = getContributionDates($contributionGraphs);
+        $stats = getContributionStats($contributions);
+
+        $expected = [
+            "mode" => "daily",
+            "totalContributions" => 6,
+            "firstContribution" => "2026-07-08",
+            "longestStreak" => [
+                "start" => "2026-07-08",
+                "end" => "2026-07-10",
+                "length" => 3,
+            ],
+            "currentStreak" => [
+                "start" => "2026-07-08",
+                "end" => "2026-07-10",
+                "length" => 3,
+            ],
+            "excludedDays" => [],
+        ];
+        $this->assertEquals(["2026-07-08" => 2, "2026-07-09" => 1, "2026-07-10" => 3], $contributions);
+        $this->assertEquals($expected, $stats);
+    }
+
+    /**
      * Test weekly stats
      */
     public function testWeeklyStats(): void


### PR DESCRIPTION
## Summary
- Fetch repository creation contributions from GitHub's contributionsCollection
- Merge repository creation dates into the daily contribution map without double-counting days already counted by the calendar
- Add regression coverage for a repo-creation-only day preserving the daily streak

Closes #919

## Tests
- TOKEN=dummy ./vendor/bin/phpunit --testdox tests/StatsTest.php --filter testRepositoryCreationContribution
- php -l src/stats.php
- php -l tests/StatsTest.php
- npx prettier --check src/stats.php tests/StatsTest.php
- git diff --check

## Notes
- repositoryContributions(first: 100) covers up to 100 created repositories within a queried year. Handling more would require paginating repositoryContributions in the contribution graph fetch path.